### PR TITLE
Fix cast of pointers to integers of different size

### DIFF
--- a/plugins/block_diagram.h
+++ b/plugins/block_diagram.h
@@ -9,13 +9,14 @@
 #define __OSC_PLUGIN_BLOCK_H__
 
 #include <stdarg.h>
+#include <stdint.h>
 
 static double scale_block = 1.0;
 static int x_block = 0, y_block = 0, redraw_block = 0;
 static GtkWidget *block_diagram_events;
 static GtkWidget *next_pict, *previous_pict;
 static char *block_filename[256];
-static unsigned int block_num = 0;
+static unsigned long block_num = 0;
 
 static gboolean zoom_image_press_cb (GtkWidget *event_box, GdkEventButton *event, gpointer data)
 {
@@ -30,7 +31,7 @@ static gboolean zoom_image_press_cb (GtkWidget *event_box, GdkEventButton *event
 
 static void next_image_cb (GtkButton *btn, gpointer data)
 {
-	block_num += (long) data;
+	block_num += (uintptr_t) data;
 
 	if (block_filename[block_num + 1] == NULL)
 		gtk_widget_hide(next_pict);
@@ -49,7 +50,7 @@ static void next_image_cb (GtkButton *btn, gpointer data)
 
 static void zoom_image_cb (GtkButton *btn, gpointer data)
 {
-	switch ((long) data) {
+	switch ((uintptr_t) data) {
 		case 0:
 			scale_block += .1;
 			break;

--- a/plugins/fmcomms2.c
+++ b/plugins/fmcomms2.c
@@ -792,7 +792,7 @@ static void tx_sample_rate_changed(GtkSpinButton *spinbutton, gpointer user_data
 
 static void rx_phase_rotation_set(GtkSpinButton *spinbutton, gpointer user_data)
 {
-	glong offset = (glong) user_data;
+	uintptr_t offset = (uintptr_t) user_data;
 	struct iio_channel *out0, *out1;
 	gdouble val, phase;
 

--- a/plugins/fmcomms2_adv.c
+++ b/plugins/fmcomms2_adv.c
@@ -1025,7 +1025,7 @@ void tx_phase_hscale_value_changed (GtkRange *hscale1, gpointer data)
 {
 	double value = gtk_range_get_value(hscale1);
 
-	if ((unsigned long)data)
+	if ((uintptr_t) data)
 		trx_phase_rotation(dev_dds_master, value);
 	else
 		trx_phase_rotation(dev_dds_slave, value);

--- a/plugins/fmcomms5.c
+++ b/plugins/fmcomms5.c
@@ -822,7 +822,7 @@ static void tx_sample_rate_changed(GtkSpinButton *spinbutton, gpointer user_data
 
 static void rx_phase_rotation_set(GtkSpinButton *spinbutton, gpointer user_data)
 {
-	glong offset = (glong) user_data;
+	uintptr_t offset = (uintptr_t) user_data;
 	struct iio_device *dev;
 	struct iio_channel *out0, *out1;
 	gdouble val, phase;


### PR DESCRIPTION
For some reason, under MinGW and when building for x86_64,
the pointers are 64-bit but the 'long' type is only 32-bit.
Go figure.

With this last commit applied, the OSC builds fine in MinGW with both the 32-bit and the 64-bit configurations.