### PR TITLE
Staticify the functions of the plugins (except SCPI)

### DIFF
--- a/plugins/debug.c
+++ b/plugins/debug.c
@@ -571,7 +571,7 @@ static void spin_or_combo_changed_cb(GtkSpinButton *spinbutton,
 	gtk_label_set_text((GtkLabel *)label_reg_hex_value, buf);
 }
 
-void detailed_regmap_toggled_cb(GtkToggleButton *btn, gpointer data)
+static void detailed_regmap_toggled_cb(GtkToggleButton *btn, gpointer data)
 {
 	char *current_device;
 
@@ -592,7 +592,7 @@ static void reg_map_type_changed_cb(GtkComboBox box, gpointer data)
 	detailed_regmap_toggled_cb(GTK_TOGGLE_BUTTON(toggle_detailed_regmap), NULL);
 }
 
-void debug_panel_destroy_cb(GObject *object, gpointer user_data)
+static void debug_panel_destroy_cb(GObject *object, gpointer user_data)
 {
 	destroy_device_context();
 }

--- a/plugins/dmm.c
+++ b/plugins/dmm.c
@@ -218,7 +218,7 @@ static void device_toggled(GtkCellRendererToggle* renderer, gchar* pathStr, gpoi
 	build_channel_list();
 }
 
-void channel_toggle(GtkCellRendererToggle* renderer, gchar* pathStr, gpointer data)
+static void channel_toggle(GtkCellRendererToggle* renderer, gchar* pathStr, gpointer data)
 {
 	GtkTreePath* path = gtk_tree_path_new_from_string(pathStr);
 	GtkTreeIter iter;

--- a/plugins/fmcomms1.c
+++ b/plugins/fmcomms1.c
@@ -343,7 +343,7 @@ static void tx_sample_rate_changed(void *data)
 	}
 }
 
-struct fmcomms1_calib_data_v1 *find_entry(struct fmcomms1_calib_data_v1 *data,
+static struct fmcomms1_calib_data_v1 *find_entry(struct fmcomms1_calib_data_v1 *data,
 					 struct fmcomms1_calib_header_v1 *header,
 					 unsigned f)
 {
@@ -365,7 +365,7 @@ struct fmcomms1_calib_data_v1 *find_entry(struct fmcomms1_calib_data_v1 *data,
 	return &data[gindex];
 }
 
-void store_entry_hw(struct fmcomms1_calib_data_v1 *data, unsigned tx, unsigned rx)
+static void store_entry_hw(struct fmcomms1_calib_data_v1 *data, unsigned tx, unsigned rx)
 {
 	if (!data)
 		return;
@@ -927,7 +927,7 @@ display_call_ret:
 }
 
 
-char * get_filename(char *name, bool load)
+static char * get_filename(char *name, bool load)
 {
 	gint ret;
 	char *filename, buf[256];
@@ -1112,7 +1112,7 @@ static int parse_cal_handler(int line, const char* section,
 	return 0;
 }
 
-void load_cal(char * resfile)
+static void load_cal(char * resfile)
 {
 	foreach_in_ini(resfile, parse_cal_handler);
 }
@@ -1165,7 +1165,7 @@ static int cal_save_to_eeprom(struct s_cal_eeprom_v1 *eeprom)
 	return 0;
 }
 
-void save_cal(char * resfile)
+static void save_cal(char * resfile)
 {
 	FILE* file;
 	time_t clock = time(NULL);
@@ -1244,7 +1244,7 @@ static void calib_plot_destroyed_cb(OscPlot *plot)
 	g_signal_emit_by_name(GTK_DIALOG(dialogs.calibrate), "response", -7);
 }
 
-G_MODULE_EXPORT void cal_dialog(GtkButton *btn, Dialogs *data)
+static void cal_dialog(GtkButton *btn, Dialogs *data)
 {
 	gint ret;
 	char *filename = NULL;

--- a/plugins/fmcomms2.c
+++ b/plugins/fmcomms2.c
@@ -544,7 +544,7 @@ static void update_widgets(void)
 	dxco_widgets_update();
 }
 
-void filter_fir_update(void)
+static void filter_fir_update(void)
 {
 	bool rx = false, tx = false, rxtx = false;
 	struct iio_channel *chn;
@@ -568,7 +568,7 @@ void filter_fir_update(void)
 	}
 }
 
-void filter_fir_enable(GtkToggleButton *button, gpointer data)
+static void filter_fir_enable(GtkToggleButton *button, gpointer data)
 {
 	bool rx, tx, rxtx, disable;
 
@@ -750,7 +750,7 @@ static int load_fir_filter(const char *file_name)
 	return ret;
 }
 
-void filter_fir_config_file_set_cb (GtkFileChooser *chooser, gpointer data)
+static void filter_fir_config_file_set_cb (GtkFileChooser *chooser, gpointer data)
 {
 	char *file_name = gtk_file_chooser_get_filename(chooser);
 
@@ -828,7 +828,7 @@ static void rx_phase_rotation_set(GtkSpinButton *spinbutton, gpointer user_data)
  * Return 1 if the channel combination is valid
  * Return 0 if the combination is not valid
  */
-int channel_combination_check(struct iio_device *dev, const char **ch_names)
+static int channel_combination_check(struct iio_device *dev, const char **ch_names)
 {
 	bool consecutive_ch = FALSE;
 	unsigned int i, k, nb_channels = iio_device_get_channels_count(dev);
@@ -891,7 +891,7 @@ static void make_widget_update_signal_based(struct iio_widget *widgets,
 	}
 }
 
-int handle_external_request (const char *request)
+static int handle_external_request (const char *request)
 {
 	int ret = 0;
 

--- a/plugins/fmcomms2_adv.c
+++ b/plugins/fmcomms2_adv.c
@@ -410,7 +410,7 @@ static void reload_settings(void)
 	}
 }
 
-void signal_handler_cb (GtkWidget *widget, gpointer data)
+static void signal_handler_cb (GtkWidget *widget, gpointer data)
 {
 	struct w_info *item = data;
 	unsigned val;
@@ -974,7 +974,7 @@ calibrate_fail:
 	g_thread_exit(NULL);
 }
 
-void do_calibration (GtkWidget *widget, gpointer data)
+static void do_calibration (GtkWidget *widget, gpointer data)
 {
 	GtkToggleButton *silent_calib;
 
@@ -1001,7 +1001,7 @@ void do_calibration (GtkWidget *widget, gpointer data)
 	g_thread_new("Calibrate_thread", (void *) &calibrate, data);
 }
 
-void undo_calibration (GtkWidget *widget, gpointer data)
+static void undo_calibration (GtkWidget *widget, gpointer data)
 {
 	struct osc_plugin *plugin;
 	GSList *node;
@@ -1022,7 +1022,7 @@ void undo_calibration (GtkWidget *widget, gpointer data)
 	}
 }
 
-void tx_phase_hscale_value_changed (GtkRange *hscale1, gpointer data)
+static void tx_phase_hscale_value_changed (GtkRange *hscale1, gpointer data)
 {
 	double value = gtk_range_get_value(hscale1);
 
@@ -1033,7 +1033,7 @@ void tx_phase_hscale_value_changed (GtkRange *hscale1, gpointer data)
 
 }
 
-void bist_tone_cb (GtkWidget *widget, gpointer data)
+static void bist_tone_cb (GtkWidget *widget, gpointer data)
 {
 	GtkBuilder *builder = data;
 	unsigned mode, level, freq, c2i, c2q, c1i, c1q;
@@ -1143,7 +1143,7 @@ static int update_widgets(GtkBuilder *builder)
 	return iio_device_debug_attr_read_all(dev, __update_widget, builder);
 }
 
-void change_page_cb (GtkNotebook *notebook, GtkNotebookPage *page,
+static void change_page_cb (GtkNotebook *notebook, GtkNotebookPage *page,
 		     guint page_num, gpointer user_data)
 {
 	GtkWidget *tohide = user_data;
@@ -1154,7 +1154,7 @@ void change_page_cb (GtkNotebook *notebook, GtkNotebookPage *page,
 		gtk_widget_show(tohide);
 }
 
-int handle_external_request (const char *request)
+static int handle_external_request (const char *request)
 {
 	int ret = 0;
 

--- a/plugins/fmcomms5.c
+++ b/plugins/fmcomms5.c
@@ -521,7 +521,7 @@ static gboolean update_display(void)
 	return TRUE;
 }
 
-void filter_fir_update(void)
+static void filter_fir_update(void)
 {
 	bool rx = false, tx = false, rxtx = false;
 	struct iio_channel *chn;
@@ -546,7 +546,7 @@ void filter_fir_update(void)
 	glb_settings_update_labels();
 }
 
-void filter_fir_enable(GtkToggleButton *button, gpointer data)
+static void filter_fir_enable(GtkToggleButton *button, gpointer data)
 {
 	bool rx, tx, rxtx, disable;
 
@@ -811,7 +811,7 @@ static int load_fir_filter(const char *file_name)
 	return ret;
 }
 
-void filter_fir_config_file_set_cb (GtkFileChooser *chooser, gpointer data)
+static void filter_fir_config_file_set_cb (GtkFileChooser *chooser, gpointer data)
 {
 	char *file_name = gtk_file_chooser_get_filename(chooser);
 
@@ -874,7 +874,7 @@ static void rx_phase_rotation_set(GtkSpinButton *spinbutton, gpointer user_data)
  * Return 1 if the channel combination is valid
  * Return 0 if the combination is not valid
  */
-int channel_combination_check(struct iio_device *dev, const char **ch_names)
+static int channel_combination_check(struct iio_device *dev, const char **ch_names)
 {
 	bool consecutive_ch = FALSE;
 	unsigned int i, k, nb_channels = iio_device_get_channels_count(dev);
@@ -937,7 +937,7 @@ static void make_widget_update_signal_based(struct iio_widget *widgets,
 	}
 }
 
-int handle_external_request (const char *request)
+static int handle_external_request (const char *request)
 {
 	int ret = 0;
 

--- a/plugins/motor_control.c
+++ b/plugins/motor_control.c
@@ -143,7 +143,7 @@ static void tx_update_values(void)
 	iio_update_widgets(tx_widgets, num_tx);
 }
 
-void save_widget_value(GtkWidget *widget, struct iio_widget *iio_w)
+static void save_widget_value(GtkWidget *widget, struct iio_widget *iio_w)
 {
 	iio_w->save(iio_w);
 }
@@ -337,7 +337,7 @@ static void resolver_resolution_changed_cb(GtkComboBoxText *box,
 	}
 }
 
-void create_iio_bindings_for_pid_ctrl(GtkBuilder *builder,
+static void create_iio_bindings_for_pid_ctrl(GtkBuilder *builder,
 		enum pid_no i)
 {
 	struct iio_device *pid_dev = pid_devs[i];
@@ -367,7 +367,7 @@ void create_iio_bindings_for_pid_ctrl(GtkBuilder *builder,
 	pwm_pid[i] = tx_widgets[num_tx - 1].widget;
 }
 
-void create_iio_bindings_for_advanced_ctrl(GtkBuilder *builder)
+static void create_iio_bindings_for_advanced_ctrl(GtkBuilder *builder)
 {
 	iio_toggle_button_init_from_builder(&tx_widgets[num_tx++],
 		adv_dev, NULL, "mc_adv_ctrl_run",

--- a/plugins/pr_config.c
+++ b/plugins/pr_config.c
@@ -170,7 +170,7 @@ static void readReg(char* device, uint32_t address, uint32_t* data) {
 	iio_device_reg_read(dev, address, data);
 }
 
-int getPrId() {
+static int getPrId() {
 
 	uint32_t data = 0;
 


### PR DESCRIPTION
The plugins don't need to export anything else than the "plugin"
variable, except for the SCPI plugin.

This fixes a bug occuring on Windows, where the fmcomms1 plugin would
never load.

Signed-off-by: Paul Cercueil <paul.cercueil@analog.com>