### PR TITLE
Add support for writing/reading EEPROM tuning params

### DIFF
--- a/plugins/scpi.c
+++ b/plugins/scpi.c
@@ -877,8 +877,7 @@ int scpi_counter_get_freq(double *freq, double target_freq)
 
 	ret = sscanf(freq_str, "%lf", freq);
 
-	if (freq_str)
-		g_free(freq_str);
+	g_free(freq_str);
 
 	if (ret == 1)
 		*freq *= scale;


### PR DESCRIPTION
Note that this requires the latest changes to fru_tools (the -t option for fru-dump) to be able to save values to the EEPROM properly.