### PR TITLE
build: fix & update dependency checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PKG_CONFIG_PATH := $(SYSROOT)/usr/share/pkgconfig:$(SYSROOT)/usr/lib/pkgconfig:$
 PKG_CONFIG := env PKG_CONFIG_SYSROOT_DIR="$(SYSROOT)" \
 	PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config
 
-DEPENDENCIES := glib-2.0 gtk+-2.0 gthread-2.0 gtkdatabox fftw3 libiio libxml-2.0 libcurl jansson
+DEPENDENCIES := glib-2.0 gtk+-2.0 gthread-2.0 gtkdatabox fftw3 libiio libxml-2.0 libcurl jansson matio libad9361
 
 DEP_CFLAGS=
 DEP_LDFLAGS=

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,16 @@ PKG_CONFIG := env PKG_CONFIG_SYSROOT_DIR="$(SYSROOT)" \
 
 DEPENDENCIES := glib-2.0 gtk+-2.0 gthread-2.0 gtkdatabox fftw3 libiio libxml-2.0 libcurl jansson
 
-LDFLAGS := $(shell $(PKG_CONFIG) --libs $(DEPENDENCIES)) \
+DEP_CFLAGS=
+DEP_LDFLAGS=
+define dep_flags
+DEP_CFLAGS+=$(shell $(PKG_CONFIG) --cflags $(1))
+DEP_LDFLAGS+=$(shell $(PKG_CONFIG) --libs $(1))
+endef
+
+$(foreach dep,$(DEPENDENCIES),$(eval $(call dep_flags,$(dep))))
+
+LDFLAGS := $(DEP_LDFLAGS) \
 	$(if $(WITH_MINGW),-lwinpthread) \
 	-L$(SYSROOT)/usr/lib -lmatio -lz -lm -lad9361
 
@@ -37,7 +46,7 @@ else
 	LDFLAGS += -rdynamic
 endif
 
-CFLAGS := $(shell $(PKG_CONFIG) --cflags $(DEPENDENCIES)) \
+CFLAGS := $(DEP_CFLAGS) \
 	-I$(SYSROOT)/usr/include $(if $(WITH_MINGW),-mwindows,-fPIC) \
 	-Wall -Wclobbered -Wempty-body -Wignored-qualifiers -Wmissing-field-initializers \
 	-Wmissing-parameter-type -Wold-style-declaration -Woverride-init \


### PR DESCRIPTION
* iterate over all dependencies to find out which one is missing ; pkg-config is a all-or-nothing method ; so if any dependency is missing, it will always point to glib as not being found
* dependency check is the first build step ; this has been made sure to run as first even for multi-job builds
* Added checks for `matio` and `libad9361-iio` to dep check

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>