### PR TITLE
 build: organize linker search paths in LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,10 @@ $(foreach dep,$(DEPENDENCIES),$(eval $(call dep_flags,$(dep))))
 
 LDFLAGS := $(DEP_LDFLAGS) \
 	$(if $(WITH_MINGW),-lwinpthread) \
-	-L$(SYSROOT)/usr/lib -lmatio -lz -lm -lad9361
+	-L$(SYSROOT)/usr/lib64 \
+	-L$(SYSROOT)/usr/lib \
+	-L$(SYSROOT)/usr/lib32 \
+	-lmatio -lz -lm -lad9361
 
 ifeq ($(WITH_MINGW),y)
 	LDFLAGS += -Wl,--subsystem,windows


### PR DESCRIPTION
Fixes: https://github.com/analogdevicesinc/iio-oscilloscope/issues/72
Fixes: https://github.com/analogdevicesinc/iio-oscilloscope/issues/79
    
Order/preference is: /usr/lib64, /usr/lib, /usr/lib32.
Suggestion came from Edward Kigwana on Github issue #79.
This should handle most standard cases/setups.
For the exotic cases, there's usually not much we can do anyway.
    
Handling multi-arch setups is not always straightforward on all distros and
the simplest way is to organize linker search paths, so that one has a
preference over the other.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>