### PR TITLE
oscplot.c: fix/add omitted break statements

### DIFF
--- a/oscplot.c
+++ b/oscplot.c
@@ -3039,11 +3039,13 @@ static void channels_transform_assignment(GtkTreeModel *model,
 			prm->ch_settings = g_slist_reverse(prm->ch_settings);
 			transform = add_transform_to_list(plot, CROSS_CORRELATION_TRANSFORM, prm->ch_settings);
 		}
+		break;
 	case SPECTRUM_PLOT:
 		if (prm->enabled_channels == 2 && num_added_chs == 2) {
 			prm->ch_settings = g_slist_reverse(prm->ch_settings);
 			transform = add_transform_to_list(plot, FREQ_SPECTRUM_TRANSFORM, prm->ch_settings);
 		}
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
These were found by enabling some extra checks for the compiler.
They are small bugs that should be fixed.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>