### PR TITLE
plugins/scpi: remove argument in scpi_rx_setup() call

### DIFF
--- a/plugins/scpi.c
+++ b/plugins/scpi.c
@@ -981,7 +981,7 @@ static int scpi_handle(int line, const char *attrib, const char *value)
 		}
 	} else { /* current_instrument == &spectrum_analyzer */
 		if (MATCH_ATTRIB("setup")) {
-			scpi_rx_setup(current_instrument);
+			scpi_rx_setup();
 		} else if (MATCH_ATTRIB("center")) {
 			scpi_rx_set_center_frequency(atoll(value));
 		} else if (MATCH_ATTRIB("span")) {


### PR DESCRIPTION
Fixes https://github.com/analogdevicesinc/iio-oscilloscope/issues/71

The `scpi_rx_setup()` function does not take any args, but it's called
with one.
The compiler does not seem to complain, especially when checks are a bit lax.
And even though this is not a problem (functionally), it is incorrect (a
bug). This fixes it.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>