### PR TITLE
daq2: Fix DAC data alignment

### DIFF
--- a/plugins/daq2.c
+++ b/plugins/daq2.c
@@ -332,6 +332,7 @@ static GtkWidget * daq2_init(GtkWidget *notebook, const char *ini_fn)
 	rx_update_values();
 	dac_data_manager_update_iio_widgets(dac_tx_manager);
 
+	dac_data_manager_set_buffer_size_alignment(dac_tx_manager, 16);
 	dac_data_manager_set_buffer_chooser_current_folder(dac_tx_manager, OSC_WAVEFORM_FILE_PATH);
 
 	block_diagram_init(builder, 4,


### PR DESCRIPTION
The daq2 platform uses a 128-bit transmit data bus and hence requires a 16 byte
size alignment on transmit waveform data.

The default alignment is 8 bytes. If a waveform is only 8 bytes aligned and not
16 byte this will cause the last 8 bytes of the waveform to be truncated on the
daq2 platform causing a discontinuity.

To fix this properly configure the required alignment in the daq2 plugin.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>