### PR TITLE
Code cleanups: part 1: implement cleanups from previous review, Codacy & cppcheck

### DIFF
--- a/dialogs.c
+++ b/dialogs.c
@@ -463,7 +463,8 @@ nope:
 }
 
 #ifdef SERIAL_BACKEND
-static void refresh_serial(void) {
+static void refresh_serial(GtkBuilder *builder)
+{
 	GtkListStore *liststore;
 	struct sp_port **ports;
 	int i;
@@ -485,6 +486,15 @@ static void refresh_serial(void) {
 		gtk_widget_set_sensitive(dialogs.connect_serialbr, false);
 		gtk_widget_set_sensitive(dialogs.connect_serial, false);
 	}
+}
+#else
+static void refresh_serial(GtkBuilder *builder)
+{
+	/* Serial Backend - hide if not supported */
+	gtk_widget_hide(dialogs.connect_seriald);
+	gtk_widget_hide(dialogs.connect_serial);
+	gtk_widget_hide(dialogs.connect_serialbr);
+	gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object(builder, "connect_serial_label")));
 }
 #endif
 
@@ -1164,19 +1174,8 @@ void dialogs_init(GtkBuilder *builder)
 		}
 	}
 
-	/* Serial Backend - hide if not supported */
-#ifndef SERIAL_BACKEND
-	gtk_widget_hide(dialogs.connect_seriald);
-	gtk_widget_hide(dialogs.connect_serial);
-	gtk_widget_hide(dialogs.connect_serialbr);
-	gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object(builder, "connect_serial_label")));
-#endif
-
 	refresh_usb();
-	
-#ifdef SERIAL_BACKEND
-	refresh_serial();
-#endif
+	refresh_serial(builder);
 
 	g_signal_connect(dialogs.net_ip, "key-press-event",
 			(GCallback) connect_key_press_cb, dialogs.connect);

--- a/dialogs.c
+++ b/dialogs.c
@@ -354,12 +354,10 @@ static struct iio_context * get_context(Dialogs *data)
 				GTK_COMBO_BOX(dialogs.connect_serialbr));
 
 		/* Size is +3: for ':', ',' and '\0' */
-		int buf_size = sizeof("serial:") + strlen(port) + strlen(baud_rate) + 3;
-		gchar *result = malloc(buf_size);
-		snprintf(result, buf_size, "serial:%s,%s", port, baud_rate);
+		gchar *result = g_strdup_printf("serial:%s,%s", port, baud_rate);
 
 		ctx = iio_create_context_from_uri(result);
-		free(result);
+		g_free(result);
 		if (!ctx && errno == EBUSY &&
 				!strcmp("serial", iio_context_get_name(get_context_from_osc()))) {
 			return get_context_from_osc();

--- a/osc.c
+++ b/osc.c
@@ -1053,7 +1053,7 @@ static void apply_trigger_offset(const struct iio_channel *chn, off_t offset)
 	if (offset) {
 		struct extra_info *info = iio_channel_get_data(chn);
 
-		memmove(info->data_ref, (void *) info->data_ref + offset,
+		memmove(info->data_ref, info->data_ref + offset,
 				info->offset * sizeof(gfloat) - offset);
 	}
 }

--- a/oscplot.c
+++ b/oscplot.c
@@ -2683,7 +2683,7 @@ static void markers_phase_diff_show(OscPlotPrivate *priv)
 		filter = 1.0 / filter;
 
 		if (MAX_MARKERS && priv->marker_type != MARKER_OFF) {
-			for (m = 0; m <= MAX_MARKERS &&
+			for (m = 0; m < MAX_MARKERS &&
 						trA_markers[m].active; m++) {
 
 				/* find out the quadrant
@@ -2737,7 +2737,7 @@ static void markers_phase_diff_show(OscPlotPrivate *priv)
 					angle,
 					/* lo_freq / markers_scale */ trA_markers[m].x,
 					/*dev_info->adc_scale */ 'M',
-					m != MAX_MARKERS ? '\n' : '\0');
+					m != (MAX_MARKERS - 1) ? '\n' : '\0');
 
 				gtk_text_buffer_insert(priv->phase_buf,
 						&iter, text, -1);

--- a/oscplot.c
+++ b/oscplot.c
@@ -5519,7 +5519,7 @@ static void set_marker_labels (OscPlot *plot, gchar *buf, enum marker_types type
 		return;
 	}
 
-	fprintf(stderr, "unhandled event at %s : %s\n", __func__, buf);
+	fprintf(stderr, "unhandled event at %s : %s\n", __func__, buf ? buf : "<null>");
 }
 
 static void marker_menu (struct string_and_plot *string_data)

--- a/oscplot.c
+++ b/oscplot.c
@@ -712,15 +712,23 @@ double osc_plot_get_sample_count (OscPlot *plot) {
 
 void osc_plot_set_channel_state(OscPlot *plot, const char *dev, unsigned int channel, bool state)
 {
-	OscPlotPrivate *priv = plot->priv;
-	struct iio_context *ctx = priv->ctx;
+	OscPlotPrivate *priv;
+	struct iio_context *ctx;
 	struct iio_device *iio_dev;
 	struct iio_channel *iio_ch;
 
-	if (gtk_toggle_tool_button_get_active((GtkToggleToolButton *)priv->capture_button))
+	if (!plot || !dev)
 		return;
 
-	if (!plot || !dev)
+	priv = plot->priv;
+	if (!priv)
+		return;
+
+	ctx = priv->ctx;
+	if (!ctx)
+		return;
+
+	if (gtk_toggle_tool_button_get_active((GtkToggleToolButton *)priv->capture_button))
 		return;
 
 	iio_dev = iio_context_find_device(ctx, dev);
@@ -2170,14 +2178,22 @@ static bool plot_channel_check_name_exists(OscPlot *plot, const char *name,
 
 static int plot_get_sample_count_of_device(OscPlot *plot, const char *device)
 {
-	OscPlotPrivate *priv = plot->priv;
-	struct iio_context *ctx = priv->ctx;
+	OscPlotPrivate *priv;
+	struct iio_context *ctx;
 	struct iio_device *iio_dev;
 	struct extra_dev_info *dev_info;
 	gdouble freq;
 	int count = -1;
 
 	if (!plot || !device)
+		return count;
+
+	priv = plot->priv;
+	if (!priv)
+		return count;
+
+	ctx = priv->ctx;
+	if (!ctx)
 		return count;
 
 	switch (gtk_combo_box_get_active(GTK_COMBO_BOX(priv->hor_units))) {


### PR DESCRIPTION
This changeset implements some changes reported in PR #97 , the Codacy tool and cppcheck.

This PR will fix them and in a later PR, the Codacy & cppcheck tools will be added to run over the code.

This project is being used as a test-bed for automating some code-review stuff, with the intent to simplify the effort for code reviews.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>