### PR TITLE
rework check_valid_setup_of_device() logic

### DIFF
--- a/oscplot.c
+++ b/oscplot.c
@@ -2028,7 +2028,7 @@ static gboolean check_valid_setup_of_device(OscPlot *plot, const char *name)
 			return false;
 		}
 	} else if (plot_type == TIME_PLOT) {
-		if (enabled_channels_count(plot) == 0) {
+		if (num_enabled == 0) {
 			gtk_widget_set_tooltip_text(priv->capture_button,
 				"Time Domain needs at least one channel");
 			return false;
@@ -2038,7 +2038,7 @@ static gboolean check_valid_setup_of_device(OscPlot *plot, const char *name)
 			return false;
 		}
 	} else if (plot_type == XCORR_PLOT) {
-		if (enabled_channels_count(plot) != 4) {
+		if (num_enabled != 4) {
 			gtk_widget_set_tooltip_text(priv->capture_button,
 				"Correlation requires 2 or 4 channels");
 			return false;

--- a/oscplot.c
+++ b/oscplot.c
@@ -2904,13 +2904,15 @@ static int enabled_channels_of_device(GtkTreeView *treeview, const char *name, u
 
 	GtkTreeModel *model = gtk_tree_view_get_model(treeview);
 	gboolean next_iter = gtk_tree_model_get_iter_first(model, &iter);
+
+	if (enabled_mask)
+		*enabled_mask = 0;
+
 	while (next_iter) {
 		if (!gtk_tree_model_iter_children(model, &child_iter, &iter)) {
 			next_iter = gtk_tree_model_iter_next(model, &iter);
 			continue;
 		}
-		if (enabled_mask)
-			*enabled_mask = 0;
 		gtk_tree_model_get(model, &iter, ELEMENT_NAME, &str_device, -1);
 		if (!strcmp(name, str_device)) {
 			next_child_iter = true;


### PR DESCRIPTION
This PR takes a different approach to PR #105 
It initializes the `enabled_channel_mask` inside the `enabled_channels_of_device()` function, and re-uses the `num_enabled` in `check_valid_setup_of_device()` to save some cycles.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>