### PR TITLE
Replace snprintf() + fwrite() with fprintf()

### DIFF
--- a/plugins/ad9371.c
+++ b/plugins/ad9371.c
@@ -1775,9 +1775,7 @@ static void ad9371_get_preferred_size(int *width, int *height)
 
 static void save_widgets_to_ini(FILE *f)
 {
-	char buf[0x1000];
-
-	snprintf(buf, sizeof(buf), "load_myk_profile_file = %s\n"
+	fprintf(f, "load_myk_profile_file = %s\n"
 			"dds_mode_tx1 = %i\n"
 			"dds_mode_tx2 = %i\n"
 			"dac_buf_filename = %s\n"
@@ -1803,7 +1801,6 @@ static void save_widgets_to_ini(FILE *f)
 			!!gtk_toggle_tool_button_get_active(section_toggle[SECTION_RX]),
 			!!gtk_toggle_tool_button_get_active(section_toggle[SECTION_OBS]),
 			!!gtk_toggle_tool_button_get_active(section_toggle[SECTION_FPGA]));
-	fwrite(buf, 1, strlen(buf), f);
 }
 
 static void save_profile(const char *ini_fn)

--- a/plugins/ad9739a.c
+++ b/plugins/ad9739a.c
@@ -233,15 +233,12 @@ static GtkWidget * ad9739a_init(GtkWidget *notebook, const char *ini_fn)
 
 static void save_widgets_to_ini(FILE *f)
 {
-	char buf[0x1000];
-
-	snprintf(buf, sizeof(buf), "dds_mode = %i\n"
+	fprintf(f, "dds_mode = %i\n"
 			"dac_buf_filename = %s\n"
 			"tx_channel_0 = %i\n",
 			dac_data_manager_get_dds_mode(dac_tx_manager, DAC_DEVICE, 1),
 			dac_data_manager_get_buffer_chooser_filename(dac_tx_manager),
 			dac_data_manager_get_tx_channel_state(dac_tx_manager, 0));
-	fwrite(buf, 1, strlen(buf), f);
 }
 
 static void save_profile(const char *ini_fn)

--- a/plugins/adrv9009.c
+++ b/plugins/adrv9009.c
@@ -1297,9 +1297,7 @@ static void adrv9009_get_preferred_size(int *width, int *height)
 
 static void save_widgets_to_ini(FILE *f)
 {
-	char buf[0x1000];
-
-	snprintf(buf, sizeof(buf), "load_tal_profile_file = %s\n"
+	fprintf(f, "load_tal_profile_file = %s\n"
 	         "dds_mode_tx1 = %i\n"
 	         "dds_mode_tx2 = %i\n"
 	         "dac_buf_filename = %s\n"
@@ -1325,7 +1323,6 @@ static void save_widgets_to_ini(FILE *f)
 	         !!gtk_toggle_tool_button_get_active(section_toggle[SECTION_RX]),
 	         !!gtk_toggle_tool_button_get_active(section_toggle[SECTION_OBS]),
 	         !!gtk_toggle_tool_button_get_active(section_toggle[SECTION_FPGA]));
-	fwrite(buf, 1, strlen(buf), f);
 }
 
 static void save_profile(const char *ini_fn)

--- a/plugins/daq2.c
+++ b/plugins/daq2.c
@@ -346,9 +346,7 @@ static GtkWidget * daq2_init(GtkWidget *notebook, const char *ini_fn)
 
 static void save_widgets_to_ini(FILE *f)
 {
-	char buf[0x1000];
-
-	snprintf(buf, sizeof(buf), "dds_mode = %i\n"
+	fprintf(f, "dds_mode = %i\n"
 			"dac_buf_filename = %s\n"
 			"tx_channel_0 = %i\n"
 			"tx_channel_1 = %i\n",
@@ -356,7 +354,6 @@ static void save_widgets_to_ini(FILE *f)
 			dac_data_manager_get_buffer_chooser_filename(dac_tx_manager),
 			dac_data_manager_get_tx_channel_state(dac_tx_manager, 0),
 			dac_data_manager_get_tx_channel_state(dac_tx_manager, 1));
-	fwrite(buf, 1, strlen(buf), f);
 }
 
 static void save_profile(const char *ini_fn)

--- a/plugins/fmcomms1.c
+++ b/plugins/fmcomms1.c
@@ -1999,9 +1999,7 @@ update_widgets:
 
 static void save_widgets_to_ini(FILE *f)
 {
-	char buf[0x1000];
-
-	snprintf(buf, sizeof(buf), "dds_mode = %i\n"
+	fprintf(f, "dds_mode = %i\n"
 			"dac_buf_filename = %s\n"
 			"tx_channel_0 = %i\n"
 			"tx_channel_1 = %i\n"
@@ -2011,7 +2009,6 @@ static void save_widgets_to_ini(FILE *f)
 			dac_data_manager_get_tx_channel_state(dac_tx_manager, 0),
 			dac_data_manager_get_tx_channel_state(dac_tx_manager, 1),
 			!!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gain_locked)));
-	fwrite(buf, 1, strlen(buf), f);
 }
 
 static void save_profile(const char *ini_fn)

--- a/plugins/fmcomms11.c
+++ b/plugins/fmcomms11.c
@@ -337,9 +337,7 @@ static GtkWidget * fmcomms11_init(GtkWidget *notebook, const char *ini_fn)
 
 static void save_widgets_to_ini(FILE *f)
 {
-	char buf[0x1000];
-
-	snprintf(buf, sizeof(buf), "dds_mode = %i\n"
+	fprintf(f, "dds_mode = %i\n"
 			"dac_buf_filename = %s\n"
 			"tx_channel_0 = %i\n"
 			"tx_channel_1 = %i\n",
@@ -347,7 +345,6 @@ static void save_widgets_to_ini(FILE *f)
 			dac_data_manager_get_buffer_chooser_filename(dac_tx_manager),
 			dac_data_manager_get_tx_channel_state(dac_tx_manager, 0),
 			dac_data_manager_get_tx_channel_state(dac_tx_manager, 1));
-	fwrite(buf, 1, strlen(buf), f);
 }
 
 static void save_profile(const char *ini_fn)

--- a/plugins/fmcomms2.c
+++ b/plugins/fmcomms2.c
@@ -2046,9 +2046,7 @@ static void fmcomms2_get_preferred_size(int *width, int *height)
 
 static void save_widgets_to_ini(FILE *f)
 {
-	char buf[0x1000];
-
-	snprintf(buf, sizeof(buf), "load_fir_filter_file = %s\n"
+	fprintf(f, "load_fir_filter_file = %s\n"
 			"dds_mode_tx1 = %i\n"
 			"dds_mode_tx2 = %i\n"
 			"tx_channel_0 = %i\n"
@@ -2074,7 +2072,6 @@ static void save_widgets_to_ini(FILE *f)
 			!!gtk_toggle_tool_button_get_active(section_toggle[SECTION_TX]),
 			!!gtk_toggle_tool_button_get_active(section_toggle[SECTION_RX]),
 			!!gtk_toggle_tool_button_get_active(section_toggle[SECTION_FPGA]));
-	fwrite(buf, 1, strlen(buf), f);
 }
 
 static void save_profile(const char *ini_fn)

--- a/plugins/fmcomms5.c
+++ b/plugins/fmcomms5.c
@@ -1660,9 +1660,7 @@ static void fmcomms5_get_preferred_size(int *width, int *height)
 
 static void save_widgets_to_ini(FILE *f)
 {
-	char buf[0x1000];
-
-	snprintf(buf, sizeof(buf), "load_fir_filter_file = %s\n"
+	fprintf(f, "load_fir_filter_file = %s\n"
 			"dds_mode_tx1 = %i\n"
 			"dds_mode_tx2 = %i\n"
 			"dds_mode_tx3 = %i\n"
@@ -1698,7 +1696,6 @@ static void save_widgets_to_ini(FILE *f)
 			!!gtk_toggle_tool_button_get_active(section_toggle[SECTION_TX]),
 			!!gtk_toggle_tool_button_get_active(section_toggle[SECTION_RX]),
 			!!gtk_toggle_tool_button_get_active(section_toggle[SECTION_FPGA]));
-	fwrite(buf, 1, strlen(buf), f);
 }
 
 

--- a/plugins/motor_control.c
+++ b/plugins/motor_control.c
@@ -736,9 +736,7 @@ static void update_active_page(gint active_page, gboolean is_detached)
 
 static void save_widgets_to_ini(FILE *f)
 {
-	char buf[0x1000];
-
-	snprintf(buf, sizeof(buf), "pwm = %s\n"
+	fprintf(f, "pwm = %s\n"
 			"gpo.1 = %i\n"
 			"gpo.2 = %i\n"
 			"gpo.3 = %i\n"
@@ -762,7 +760,6 @@ static void save_widgets_to_ini(FILE *f)
 			gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gpo[8])),
 			gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gpo[9])),
 			gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gpo[10])));
-	fwrite(buf, 1, strlen(buf), f);
 }
 
 static void save_profile(const char *ini_fn)

--- a/plugins/pr_config.c
+++ b/plugins/pr_config.c
@@ -372,13 +372,10 @@ static void pr_config_get_preferred_size(int *width, int *height)
 
 static void save_widgets_to_ini(FILE *f)
 {
-	char buf[0x1000];
-
-	snprintf(buf, sizeof(buf), "config_file = %s\n"
+	fprintf(f, "config_file = %s\n"
 			"adc_active = %i\n",
 			config_file_path,
 			gtk_combo_box_get_active(GTK_COMBO_BOX(regmap_select)) == ADC_REGMAP);
-	fwrite(buf, 1, strlen(buf), f);
 }
 
 static void save_profile(const char *ini_fn)

--- a/plugins/scpi.c
+++ b/plugins/scpi.c
@@ -1372,12 +1372,11 @@ static GtkWidget * scpi_init(GtkWidget *notebook, const char *ini_fn)
 
 static void scpi_save_profile(const char *ini_fn)
 {
-	char buf[0x1000];
 	FILE *f = fopen(ini_fn, "a");
 	if (!f)
 		return;
 
-	snprintf(buf, sizeof(buf),
+	fprintf(f,
 			"\n[" THIS_DRIVER "]\n"
 			"tx.serial = %i\n"
 			"tx.network = %i\n"
@@ -1403,7 +1402,6 @@ static void scpi_save_profile(const char *ini_fn)
 			spectrum_analyzer.ip_address,
 			spectrum_analyzer.tty_path,
 			spectrum_analyzer.gpib_addr);
-	fwrite(buf, 1, strlen(buf), f);
 	fclose(f);
 }
 


### PR DESCRIPTION
Replace the sequence of

	snprintf(buf, ...);
	fwrite(buf, ..., f);
with
	fprintf(f, ...);

This is semantically equivalent for the most part but removes the need for
a temporary buffer. This new solution differs in that the data written is
not truncated if it exceeds the size of the original temporary buffer.

Bulk of the transformation was done using the following coccinelle semantic
patch:

// <smpl>
@@
expression buf;
expression len;
expression f;
@@
+fprinf(f,
-snprintf(buf, len,
 ...);
-fwrite(buf, ..., f);
// </smpl>

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>