### PR TITLE
Makefile: Remove serial backend to allow building on the SD card image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ LDFLAGS := $(DEP_LDFLAGS) \
 	-L$(SYSROOT)/usr/lib64 \
 	-L$(SYSROOT)/usr/lib \
 	-L$(SYSROOT)/usr/lib32 \
-	-lmatio -lz -lm -lad9361 -lserialport
+	-lmatio -lz -lm -lad9361
 
 ifeq ($(WITH_MINGW),y)
 	LDFLAGS += -Wl,--subsystem,windows
@@ -66,7 +66,6 @@ CFLAGS := $(DEP_CFLAGS) \
 	$(GIT_COMMIT_TIMESTAMP) \
 	-DOSC_VERSION=\"$(OSC_VERSION)\" \
 	-D_POSIX_C_SOURCE=200809L \
-	-DSERIAL_BACKEND
 
 DEBUG ?= 0
 ifeq ($(DEBUG),1)


### PR DESCRIPTION
This allows building osc on the embedded Ubuntu image. The makefile based
build will be dropped soon in favor of the cmake based build. But for
now make sure we can build OSC on our embedded targets.


Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>