### PR TITLE
Added preprocessor condition to provide access to plugins under macOS.

### DIFF
--- a/osc.c
+++ b/osc.c
@@ -909,6 +909,9 @@ static void load_plugins(GtkWidget *notebook, const char *ini_fn)
 #ifdef __MINGW32__
 		if (!str_endswith(ent->d_name, ".dll"))
 			continue;
+#elif __APPLE__
+		 if (!str_endswith(ent->d_name, ".dylib"))
+			continue;
 #else
 		if (!str_endswith(ent->d_name, ".so"))
 			continue;


### PR DESCRIPTION
When the plugins are compiled under macOS, they are created with a ".dylib" extension. However the code which currently loads the plugins, caters only for Windows ".dll" and Linux ".so" files. The modest code change in this PR now makes it possible for the plugins to be loaded on macOS devices.