### PR TITLE
osc: assume a file regular if d_type is 0

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -1,0 +1,25 @@
+
+#ifndef _COMPAT_H_
+#define _COMPAT_H_
+
+#include <dirent.h>
+
+static inline bool is_dirent_reqular_file(const struct dirent *ent)
+{
+#ifdef _DIRENT_HAVE_D_TYPE
+	/* assume regular file; though not very correct */
+	if (!ent)
+		return true;
+	if (ent->d_type == DT_REG)
+		return true;
+	/* assume regular file if d_type is 0 */
+	if (ent->d_type == 0)
+		return true;
+	return false;
+#else
+	/* assume regular file */
+	return true;
+#endif
+}
+
+#endif

--- a/dialogs.c
+++ b/dialogs.c
@@ -19,6 +19,7 @@
 
 #include <iio.h>
 
+#include "compat.h"
 #include "fru.h"
 #include "osc.h"
 #include "config.h"
@@ -129,7 +130,7 @@ static size_t write_fru(char *eeprom)
 	gtk_list_store_clear(store);
 
 	for (j = 0; j < n; j++) {
-		if (namelist[j]->d_type == DT_REG && str_endswith(namelist[j]->d_name, ".bin"))
+		if (is_dirent_reqular_file(namelist[j]) && str_endswith(namelist[j]->d_name, ".bin"))
 			gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(fru_file_list), namelist[j]->d_name);
 		free(namelist[j]);
 	}

--- a/osc.c
+++ b/osc.c
@@ -26,6 +26,7 @@
 
 #include <iio.h>
 
+#include "compat.h"
 #include "libini2.h"
 #include "osc.h"
 #include "datatypes.h"
@@ -902,10 +903,8 @@ static void load_plugins(GtkWidget *notebook, const char *ini_fn)
 			const char *ini_fn;
 		} *params;
 
-#ifdef _DIRENT_HAVE_D_TYPE
-		if (ent->d_type != DT_REG)
+		if (!is_dirent_reqular_file(ent))
 			continue;
-#endif
 #ifdef __MINGW32__
 		if (!str_endswith(ent->d_name, ".dll"))
 			continue;

--- a/xml_utils.c
+++ b/xml_utils.c
@@ -13,6 +13,7 @@
 #include <libxml/parser.h>
 #include <libxml/xpath.h>
 
+#include "compat.h"
 #include "xml_utils.h"
 
 #define MAX_STR_LEN    512
@@ -89,13 +90,7 @@ char **get_xml_list(char * buf_dir_name, int *list_size)
 	}
 
 	while ((ent = readdir(d))) {
-		bool is_regular_file;
-#ifdef _DIRENT_HAVE_D_TYPE
-		is_regular_file = ent->d_type == DT_REG;
-#else
-		is_regular_file = true;
-#endif
-		if (is_regular_file) {
+		if (is_dirent_reqular_file(ent)) {
 			extension_ptr = strstr(ent->d_name, ".xml");
 			if (extension_ptr != NULL) { /* if the entry has a ".xml" extension */
 				cnt++;


### PR DESCRIPTION
Fixes #120 

On some file-systems, the `d_type` may be invalid/un-populated.
These mixes are a bit rare/esoteric, and [in such cases] we can assume
that the files are regular, because the information is invalid.

Normally these bugs would be in the filesystem or libc, but it's trivial to
handle them here as well.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>