### PR TITLE
Add macOS brew support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,11 @@ set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
 
 link_directories(${CMAKE_PREFIX_PATH}/lib)
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	add_compile_options("-F/Library/Frameworks/")
+	link_libraries("-F/Library/Frameworks/")
+endif()
+
 add_definitions(-Dlinux -D_GNU_SOURCE 
 	-DOSC_VERSION="${OSC_VERSION}"
 	${GIT_VERSION}


### PR DESCRIPTION
This PR enables brew builds against local libiio and libad9361 installs.

Formula for brew install: https://github.com/tfcollins/homebrew-formulae/blob/master/i-i-o-oscilloscope.rb

Signed-off-by: Travis Collins <travis.collins@analog.com>