### PR TITLE
plugins/adrv9009: Lower the lower bound of the AUX PLL LO freq to zero

### DIFF
--- a/glade/adrv9009.glade
+++ b/glade/adrv9009.glade
@@ -199,7 +199,7 @@
     <property name="digits">6</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_sn_lo_freq">
-    <property name="lower">70</property>
+    <property name="lower">0</property>
     <property name="upper">6000</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>


### PR DESCRIPTION
The TX can be disabled and in this case the AUX PLL LO frequency will be 0. Therefore we remove the lower limit of the spin button (which was 70 Meg) otherwise the plugin when reads 0 will force the widget to 70 Meg and write back to the driver. And this is not desired.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>