### PR TITLE
dialogs: use iio_has_backend to test for usb backend suppport

### DIFF
--- a/dialogs.c
+++ b/dialogs.c
@@ -732,6 +732,7 @@ static gint fru_connect_dialog(Dialogs *data, bool load_profile)
 		ret = gtk_dialog_run(GTK_DIALOG(data->connect));
 		switch (ret) {
 		case GTK_RESPONSE_APPLY:
+			/* Refresh button */
 			widget_set_cursor(data->connect, GDK_WATCH);
 			connect_clear(NULL);
 			has_context = connect_fillin(data);
@@ -1125,17 +1126,10 @@ void dialogs_init(GtkBuilder *builder)
 	g_object_bind_property(dialogs.connect_net, "active", tmp, "sensitive", 0);
 	g_object_bind_property(dialogs.connect_net, "active", dialogs.net_ip, "sensitive", 0);
 
-	g_object_bind_property(dialogs.connect_usb, "active",
-		       GTK_WIDGET(gtk_builder_get_object(builder, "connect_usb_label")), "sensitive", 0);
-	g_object_bind_property(dialogs.connect_usb, "active", dialogs.connect_usbd, "sensitive", 0);
-
 	g_object_bind_property(dialogs.connect_serial, "active",
 		       GTK_WIDGET(gtk_builder_get_object(builder, "connect_serial_label")), "sensitive", 0);
 	g_object_bind_property(dialogs.connect_serial, "active", dialogs.connect_seriald, "sensitive", 0);
 	g_object_bind_property(dialogs.connect_serial, "active", dialogs.connect_serialbr, "sensitive", 0);
-
-	g_signal_connect(G_OBJECT(dialogs.connect_usbd), "changed",
-			(GCallback) hide_ok_btn, NULL);
 
 	g_signal_connect(G_OBJECT(dialogs.connect_seriald), "changed",
 			(GCallback) hide_ok_btn, NULL);
@@ -1144,9 +1138,6 @@ void dialogs_init(GtkBuilder *builder)
 			false);
 	gtk_widget_set_sensitive(GTK_WIDGET(gtk_builder_get_object(builder, "connect_serial_label")),
 			false);
-	g_signal_connect(G_OBJECT(dialogs.connect_usb), "toggled",
-			(GCallback) connect_clear, NULL);
-	gtk_widget_set_sensitive(dialogs.connect_usbd, false);
 
 	g_signal_connect(G_OBJECT(dialogs.connect_serial), "toggled",
 			(GCallback) connect_clear, NULL);
@@ -1154,16 +1145,21 @@ void dialogs_init(GtkBuilder *builder)
 	gtk_widget_set_sensitive(dialogs.connect_serialbr, false);
 
 	/* test USB backend & hide if it's not supported */
-	ctx = iio_create_context_from_uri("usb:expected_error");
-	if (errno == ENOSYS) {
+	if (!iio_has_backend("usb")) {
 		gtk_widget_hide(dialogs.connect_usbd);
 		gtk_widget_hide(dialogs.connect_usb);
 		gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object(builder, "connect_usb_label")));
-	} else if (errno != EINVAL) {
-		char buf[1024];
-		iio_strerror(errno, buf, sizeof(buf));
-		fprintf(stderr, "libiio issue - expecting 'EINVAL' (%i), and got '%s' (%i)\n",
-				EINVAL, buf, errno);
+	} else {
+		g_object_bind_property(dialogs.connect_usb, "active",
+				GTK_WIDGET(gtk_builder_get_object(builder, "connect_usb_label")),
+				"sensitive", 0);
+		g_object_bind_property(dialogs.connect_usb, "active", dialogs.connect_usbd,
+				"sensitive", 0);
+		g_signal_connect(G_OBJECT(dialogs.connect_usbd), "changed",
+				(GCallback) hide_ok_btn, NULL);
+		g_signal_connect(G_OBJECT(dialogs.connect_usb), "toggled",
+				(GCallback) connect_clear, NULL);
+		gtk_widget_set_sensitive(dialogs.connect_usbd, false);
 	}
 
 	/* Grey out the "local context" option if it is not available */


### PR DESCRIPTION
This was a function added in libiio 0.9, so use it to test things.
I think this was causing random crashes on Windows, and this will be
safer.

Signed-off-by: Robin Getz <robin.getz@analog.com>