### PR TITLE
Save/Restore: Fix saving/restoring the 'DDS mode'

### DIFF
--- a/plugins/adrv9009.c
+++ b/plugins/adrv9009.c
@@ -896,7 +896,7 @@ static int adrv9009_handle_driver(struct osc_plugin *plugin, const char *attrib,
 		}
 	} else if (!strncmp(attrib, "dds_mode_tx", sizeof("dds_mode_tx") - 1)) {
 		int tx = atoi(attrib + sizeof("dds_mode_tx") - 1);
-		dac_data_manager_set_dds_mode(dac_tx_manager, DDS_DEVICE, tx - 1, atoi(value));
+		dac_data_manager_set_dds_mode(dac_tx_manager, DDS_DEVICE, tx, atoi(value));
 	} else if (MATCH_ATTRIB("global_settings_show")) {
 		gtk_toggle_tool_button_set_active(
 		        section_toggle[SECTION_GLOBAL], !!atoi(value));
@@ -1634,8 +1634,8 @@ static void save_widgets_to_ini(FILE *f)
 		/* Save state of DDS modes. We know there are 2 TXs for each device. */
 		guint d;
 		for (d = 0; d < phy_devs_count; d++) {
-			fprintf(f, "dds_mode_tx%i=%i\n", (d * 2) + 1, dac_data_manager_get_dds_mode(dac_tx_manager, DDS_DEVICE, (d * 2) + 0));
-			fprintf(f, "dds_mode_tx%i=%i\n", (d * 2) + 2, dac_data_manager_get_dds_mode(dac_tx_manager, DDS_DEVICE, (d * 2) + 1));
+			fprintf(f, "dds_mode_tx%i=%i\n", (d * 2) + 1, dac_data_manager_get_dds_mode(dac_tx_manager, DDS_DEVICE, (d * 2) + 1));
+			fprintf(f, "dds_mode_tx%i=%i\n", (d * 2) + 2, dac_data_manager_get_dds_mode(dac_tx_manager, DDS_DEVICE, (d * 2) + 2));
 		}
 
 		/* Save state of buffer channels */

--- a/plugins/dac_data_manager.c
+++ b/plugins/dac_data_manager.c
@@ -2099,7 +2099,7 @@ void dac_data_manager_update_iio_widgets(struct dac_data_manager *manager)
 int dac_data_manager_set_dds_mode(struct dac_data_manager *manager,
 		const char *dac_name, unsigned tx_index, int mode)
 {
-	if (!manager || !dac_name)
+	if (!manager || !dac_name || !tx_index)
 		return -1;
 
 	if (mode < DDS_DISABLED  || mode > DDS_BUFFER)
@@ -2110,12 +2110,12 @@ int dac_data_manager_set_dds_mode(struct dac_data_manager *manager,
 	if (!strcmp(dac_name, iio_device_get_name(manager->dac1.iio_dac))) {
 		if (tx_index > manager->dac1.tx_count)
 			return -1;
-		dds_mode_combobox = manager->dac1.txs[tx_index].dds_mode_widget;
+		dds_mode_combobox = manager->dac1.txs[tx_index - 1].dds_mode_widget;
 	} else if (manager->dacs_count == 2 &&
 			!strcmp(dac_name, iio_device_get_name(manager->dac2.iio_dac))) {
 		if (tx_index > manager->dac2.tx_count)
 			return -1;
-		dds_mode_combobox = manager->dac2.txs[tx_index].dds_mode_widget;
+		dds_mode_combobox = manager->dac2.txs[tx_index - 1].dds_mode_widget;
 	} else {
 		return -1;
 	}
@@ -2127,7 +2127,7 @@ int dac_data_manager_set_dds_mode(struct dac_data_manager *manager,
 
 int  dac_data_manager_get_dds_mode(struct dac_data_manager *manager, const char *dac_name, unsigned tx_index)
 {
-	if (!manager || !dac_name)
+	if (!manager || !dac_name || !tx_index)
 		return 0;
 
 	GtkWidget *dds_mode_combobox;
@@ -2135,12 +2135,12 @@ int  dac_data_manager_get_dds_mode(struct dac_data_manager *manager, const char 
 	if (!strcmp(dac_name, iio_device_get_name(manager->dac1.iio_dac))) {
 		if (tx_index > manager->dac1.tx_count)
 			return 0;
-		dds_mode_combobox = manager->dac1.txs[tx_index].dds_mode_widget;
+		dds_mode_combobox = manager->dac1.txs[tx_index - 1].dds_mode_widget;
 	} else if (manager->dacs_count == 2 &&
 			!strcmp(dac_name, iio_device_get_name(manager->dac2.iio_dac))) {
 		if (tx_index > manager->dac2.tx_count)
 			return 0;
-		dds_mode_combobox = manager->dac2.txs[tx_index].dds_mode_widget;
+		dds_mode_combobox = manager->dac2.txs[tx_index - 1].dds_mode_widget;
 	} else {
 		return 0;
 	}


### PR DESCRIPTION
Fixes https://github.com/analogdevicesinc/iio-oscilloscope/issues/138

dac_data_manager_set_dds_mode() and dac_data_manager_get_dds_mode() need tx_index to start from 1 and not 0.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>