### PR TITLE
osc.c: Fix freeze for osc trigger

### DIFF
--- a/osc.c
+++ b/osc.c
@@ -1114,7 +1114,7 @@ static void apply_trigger_offset(const struct iio_channel *chn, off_t offset)
 	if (offset) {
 		struct extra_info *info = iio_channel_get_data(chn);
 
-		memmove(info->data_ref, info->data_ref + offset,
+		memmove(info->data_ref, (const char *)info->data_ref + offset,
 				info->offset * sizeof(gfloat) - offset);
 	}
 }


### PR DESCRIPTION
Commit e0bad3c7e7d6907ee72a7173fb94cdb4d7e513a0 removed void typecasting.
From memmove() reference, the src and dest parameters need to be typecasted
to void

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>