### PR TITLE
oscplot: fix memory corruption in plot_setup()

### DIFF
--- a/datatypes.h
+++ b/datatypes.h
@@ -16,7 +16,7 @@
 
 #include <iio.h>
 
-#define FORCE_UPDATE TRUE
+#define INITIAL_UPDATE TRUE
 #define NORMAL_UPDATE FALSE
 
 struct detachable_plugin {

--- a/oscplot.c
+++ b/oscplot.c
@@ -495,7 +495,7 @@ static bool is_frequency_transform(OscPlotPrivate *priv)
 	       priv->active_transform_type == FREQ_SPECTRUM_TRANSFORM;
 }
 
-void osc_plot_update_rx_lbl(OscPlot *plot, bool force_update)
+void osc_plot_update_rx_lbl(OscPlot *plot, bool initial_update)
 {
 	OscPlotPrivate *priv = plot->priv;
 	TrList *tr_list = priv->transform_list;
@@ -507,7 +507,7 @@ void osc_plot_update_rx_lbl(OscPlot *plot, bool force_update)
 	device_rx_info_update(plot);
 
 	/* Skip rescaling graphs, updating labels and others if the redrawing is currently halted. */
-	if (priv->redraw_function <= 0 && !force_update)
+	if (priv->redraw_function <= 0 && !initial_update)
 		return;
 
 	if (is_frequency_transform(priv)) {
@@ -516,7 +516,8 @@ void osc_plot_update_rx_lbl(OscPlot *plot, bool force_update)
 
 		/* In FFT mode we need to scale the x-axis according to the selected sampling frequency */
 		for (i = 0; i < tr_list->size; i++) {
-			Transform_setup(tr_list->transforms[i]);
+			if(!initial_update)
+				Transform_setup(tr_list->transforms[i]);
 			gtk_databox_graph_set_hide(tr_list->transforms[i]->graph, TRUE);
 		}
 
@@ -528,7 +529,7 @@ void osc_plot_update_rx_lbl(OscPlot *plot, bool force_update)
 			corr = dev_info->adc_freq / 2.0;
 		else
 			corr = 0;
-		if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->enable_auto_scale)) && !force_update)
+		if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->enable_auto_scale)) && !initial_update)
 			return;
 		if (priv->profile_loaded_scale)
 			return;
@@ -3254,7 +3255,7 @@ static void plot_setup(OscPlot *plot)
 		}
 	}
 
-	osc_plot_update_rx_lbl(plot, FORCE_UPDATE);
+	osc_plot_update_rx_lbl(plot, INITIAL_UPDATE);
 
 	bool show_phase_info = false;
 	if (priv->active_transform_type == COMPLEX_FFT_TRANSFORM &&

--- a/oscplot.h
+++ b/oscplot.h
@@ -44,7 +44,7 @@ void          osc_plot_destroy          (OscPlot *plot);
 void          osc_plot_set_visible      (OscPlot *plot, bool visible);
 struct iio_buffer * osc_plot_get_buffer (OscPlot *plot);
 void          osc_plot_data_update      (OscPlot *plot);
-void          osc_plot_update_rx_lbl    (OscPlot *plot, bool force_update);
+void          osc_plot_update_rx_lbl    (OscPlot *plot, bool initial_update);
 void          osc_plot_restart          (OscPlot *plot);
 bool          osc_plot_running_state    (OscPlot *plot);
 void          osc_plot_draw_start       (OscPlot *plot);


### PR DESCRIPTION
When initializing a FFT plot, plot_setup initializes the transform
as well as the X and Y axis and passes the handles to the gtkdatabox library.
After initialization osc_plot_update_rx_lbl is called which calls transform_setup,
invalidating the handles sent to the gtkdatabox. This causes gtkdatabox to apply
operations on invalid memory areas. To fix this, we make sure we don't reinitialize
the transform on initial setup.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>