### PR TITLE
make: Fix uninstall target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ uninstall-all: uninstall-common-files
 	xdg-icon-resource uninstall --noupdate --size 64 adi-osc
 	xdg-icon-resource uninstall --noupdate --size 128 adi-osc
 	xdg-icon-resource uninstall --size 256 adi-osc
-	xdg-desktop-menu uninstall osc.desktop
+	xdg-desktop-menu uninstall adi-osc.desktop
 	ldconfig
 
 install: $(if $(DEBIAN_INSTALL),install-common-files,install-all)


### PR DESCRIPTION
The uninstall target was not removing adi-osc.desktop correctly.

Signed-off-by: Nuno Sa <Nuno.Sa@analog.com>