### PR TITLE
eeprom: Fix possible segfault

### DIFF
--- a/eeprom.c
+++ b/eeprom.c
@@ -6,45 +6,65 @@
  * Licensed under the GPL-2.
  */
 
-#include <ftw.h>
-#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <libgen.h>
 
 #include "eeprom.h"
 
-static char *eeprom_path = NULL;
-
-/* Test if a given file is a valid XCOMM EEPROM file. */
-static int is_eeprom(const char *fpath, const struct stat *sb,
-		int typeflag, struct FTW *ftwbuf)
-{
-	int ret = 0;
-	char *fpath_s = strdup(fpath);
-	if (typeflag == FTW_F && !strcmp(basename(fpath_s), "eeprom") \
-			&& sb->st_size == FAB_SIZE_FRU_EEPROM) {
-		free(eeprom_path);
-		eeprom_path = strdup(fpath);
-		ret = 1;
-	}
-	free(fpath_s);
-	return ret;
-}
 
 /* Recursively search a given path (defaulting to /sys) for an XCOMM compatible
  * EEPROM file.
  *
  * If a matching EEPROM file is found the path is returned, otherwise returns
  * NULL. Note that the string for the returned path is obtained with malloc and
- * should be freed.
+ * should be freed. It's up to the caller to free the allocated moemroy.
  */
 const char *find_eeprom(const char *path)
 {
-	if (path == NULL)
-		path = "/sys";
+	char *eeprom_path = NULL;
+	char eeprom_names[512];
+	FILE *fp = NULL;
+	char cmd[512];
 
-	if (nftw(path, is_eeprom, 64, FTW_DEPTH | FTW_PHYS) == 1)
-		return eeprom_path;
-	return NULL;
+	if (path == NULL) {
+		path = "/sys";
+	}
+
+	snprintf(cmd, sizeof(cmd), "find %s -name eeprom 2>/dev/null", path);
+
+	fp = popen(cmd, "r");
+	if (fp == NULL) {
+		perror("popen");
+		return NULL;
+	}
+
+	while (fgets(eeprom_names, sizeof(eeprom_names), fp) != NULL) {
+		struct stat eeprom_file;
+		char *__basename = NULL;
+
+		if (eeprom_names[strlen(eeprom_names) - 1] == '\n')
+			eeprom_names[strlen(eeprom_names) - 1] = '\0';
+
+		__basename = strdup(eeprom_names);
+		stat(eeprom_names, &eeprom_file);
+
+		if (S_ISREG(eeprom_file.st_mode) &&
+		    !strcmp(basename(__basename), "eeprom") &&
+		    eeprom_file.st_size == FAB_SIZE_FRU_EEPROM) {
+
+			eeprom_path = strdup(eeprom_names);
+			free(__basename);
+			break;
+		}
+
+		free(__basename);
+	}
+
+	pclose(fp);
+	return eeprom_path;
 }


### PR DESCRIPTION
Remove free() call which could lead to a possible segmentation fault.
The first time find_eeprom() is called, eeprom_path is NULL. Either way,
must be the caller responsibility to free the allocated memory.

Signed-ooff-by: Nuno Sa <Nuno.Sa@analog.com>