### PR TITLE
Rename FMComms2 tabs to AD936X

### DIFF
--- a/plugins/fmcomms2.c
+++ b/plugins/fmcomms2.c
@@ -40,7 +40,7 @@
 
 #define HANNING_ENBW 1.50
 
-#define THIS_DRIVER "FMComms2/3/4"
+#define THIS_DRIVER "AD936X"
 #define PHY_DEVICE "ad9361-phy"
 #define DDS_DEVICE "cf-ad9361-dds-core-lpc"
 #define CAP_DEVICE "cf-ad9361-lpc"

--- a/plugins/fmcomms2_adv.c
+++ b/plugins/fmcomms2_adv.c
@@ -43,7 +43,7 @@
 #define DDS_DEVICE	"cf-ad9361-dds-core-lpc"
 #define DDS_SLAVE_DEVICE	"cf-ad9361-dds-core-B"
 
-#define THIS_DRIVER "FMComms2/3/4/5 Advanced"
+#define THIS_DRIVER "AD936X Advanced"
 
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))
 

--- a/profiles/AD-FREQCVT1_test.ini
+++ b/profiles/AD-FREQCVT1_test.ini
@@ -1,9 +1,9 @@
 [IIO Oscilloscope]
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
 plugin.Spectrum Analyzer.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 startup_version_check=0
 test=1
 
@@ -84,7 +84,7 @@ marker.8 = 0
 marker.9 = 0
 capture_started=1
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 debug.ad9361-phy.adi,txmon-2-lo-cm = 48
 debug.ad9361-phy.adi,txmon-1-lo-cm = 48
 debug.ad9361-phy.adi,txmon-2-front-end-gain = 2
@@ -213,7 +213,7 @@ debug.ad9361-phy.adi,ensm-enable-txnrx-control-enable = 0
 debug.ad9361-phy.adi,ensm-enable-pin-pulse-mode-enable = 0
 debug.ad9361-phy.adi,frequency-division-duplex-mode-enable = 1
 
-[FMComms2/3/4]
+[AD936X]
 load_fir_filter_file = /usr/local/lib/osc/filters/LTE20_MHz.ftr
 dds_mode_tx1 = 0
 dds_mode_tx2 = 0
@@ -319,7 +319,7 @@ capture_started=0
 # destroy plot, otherwise it keeps running as we continue
 destroy_plot = 1
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 debug.ad9361-phy.adi,txmon-2-lo-cm = 48
 debug.ad9361-phy.adi,txmon-1-lo-cm = 48
 debug.ad9361-phy.adi,txmon-2-front-end-gain = 2
@@ -448,7 +448,7 @@ debug.ad9361-phy.adi,ensm-enable-txnrx-control-enable = 0
 debug.ad9361-phy.adi,ensm-enable-pin-pulse-mode-enable = 0
 debug.ad9361-phy.adi,frequency-division-duplex-mode-enable = 1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage1_TX_LO_external = 0
 ad9361-phy.out_voltage_rf_bandwidth = 19365438
 ad9361-phy.out_voltage_filter_fir_en = 0
@@ -635,7 +635,7 @@ test.marker.4 = -120.0 -55.0
 # 5th Harmonic
 test.marker.5 = -120.0 -45.0
 
-[FMComms2/3/4]
+[AD936X]
 # attenuation 25 dB
 ad9361-phy.out_voltage1_hardwaregain = -25.000000 dB
 ad9361-phy.out_voltage0_hardwaregain = -25.000000 dB
@@ -664,7 +664,7 @@ test.marker.4 = -120.0 -55.0
 # 5th Harmonic
 test.marker.5 = -120.0 -45.0
 
-[FMComms2/3/4]
+[AD936X]
 # 8 MHz tone
 cf-ad9361-dds-core-lpc.out_altvoltage0_TX1_I_F1_frequency = 8000278
 cf-ad9361-dds-core-lpc.out_altvoltage4_TX2_I_F1_frequency = 8000278
@@ -700,7 +700,7 @@ test.marker.4 = -120.0 -55.0
 # 5th Harmonic
 test.marker.5 = -120.0 -55.0
 
-[FMComms2/3/4]
+[AD936X]
 # attenuation 25 dB
 ad9361-phy.out_voltage1_hardwaregain = -25.000000 dB
 ad9361-phy.out_voltage0_hardwaregain = -25.000000 dB

--- a/profiles/AD-TRXBOOST1_test.ini
+++ b/profiles/AD-TRXBOOST1_test.ini
@@ -1,9 +1,9 @@
 [IIO Oscilloscope]
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
 plugin.Spectrum Analyzer.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 startup_version_check=0
 test=1
 
@@ -84,7 +84,7 @@ marker.8 = 0
 marker.9 = 0
 capture_started=1
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 debug.ad9361-phy.adi,txmon-2-lo-cm = 48
 debug.ad9361-phy.adi,txmon-1-lo-cm = 48
 debug.ad9361-phy.adi,txmon-2-front-end-gain = 2
@@ -213,7 +213,7 @@ debug.ad9361-phy.adi,ensm-enable-txnrx-control-enable = 0
 debug.ad9361-phy.adi,ensm-enable-pin-pulse-mode-enable = 0
 debug.ad9361-phy.adi,frequency-division-duplex-mode-enable = 1
 
-[FMComms2/3/4]
+[AD936X]
 load_fir_filter_file = /usr/local/lib/osc/filters/LTE20_MHz.ftr
 dds_mode_tx1 = 0
 dds_mode_tx2 = 0
@@ -316,7 +316,7 @@ capture_started=0
 # destroy plot, otherwise it keeps running as we continue
 destroy_plot = 1
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 debug.ad9361-phy.adi,txmon-2-lo-cm = 48
 debug.ad9361-phy.adi,txmon-1-lo-cm = 48
 debug.ad9361-phy.adi,txmon-2-front-end-gain = 2
@@ -469,7 +469,7 @@ debug.ad9361-phy.adi,ensm-enable-pin-pulse-mode-enable = 0
 debug.ad9361-phy.adi,frequency-division-duplex-mode-enable = 1
 
 # 2 MHz tone
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage1_TX_LO_frequency = 2400000000
 ad9361-phy.out_altvoltage1_TX_LO_external = 0
 ad9361-phy.out_voltage_rf_bandwidth = 19365438
@@ -646,7 +646,7 @@ test.marker.4 = -120.0 -55.0
 # 5th Harmonic
 test.marker.5 = -90.0 -40.0
 
-[FMComms2/3/4]
+[AD936X]
 # 8 MHz tone
 cf-ad9361-dds-core-lpc.out_altvoltage0_TX1_I_F1_frequency = 8000278
 cf-ad9361-dds-core-lpc.out_altvoltage4_TX2_I_F1_frequency = 8000278

--- a/profiles/ADRV9363_test.ini
+++ b/profiles/ADRV9363_test.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 startup_version_check=0
 test=1
 
@@ -61,12 +61,12 @@ test.ad7291.in_voltage5_raw.int = 1231 1393
 # in_voltage6 and 7 aren't connected
 # if we got here, all the supplies seem to be working well.
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 # force the right clock output mode
 debug.ad9361-phy.adi,clk-output-mode-select = 1
 debug.ad9361-phy.initialize = 1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = nominal
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920
@@ -126,7 +126,7 @@ SYNC_RELOAD = 1
 # wait for device to settle
 cycle = 3000
 
-[FMComms2/3/4]
+[AD936X]
 # channels should be off, so RSSI should be low
 test.ad9361-phy.in_voltage0_rssi.int = 75 150
 test.ad9361-phy.in_voltage1_rssi.int = 75 150
@@ -145,7 +145,7 @@ SYNC_RELOAD = 1
 # wait for device to settle
 cycle = 3000
 
-[FMComms2/3/4]
+[AD936X]
 # channels should be on, so RSSI should be high
 test.ad9361-phy.in_voltage0_rssi.int = 10 50
 test.ad9361-phy.in_voltage1_rssi.int = 10 50

--- a/profiles/FMComms2_sweep.ini
+++ b/profiles/FMComms2_sweep.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 test=1
 
 [IIO Oscilloscope - Capture Window1]
@@ -47,7 +47,7 @@ tx.freq = 2401000000
 tx.on = 1
 
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = low_power
 ad9361-phy.ensm_mode = fdd
 ad9361-phy.in_voltage0_gain_control_mode = slow_attack
@@ -110,7 +110,7 @@ capture_started = 1
 [SCPI]
 tx.freq = 505000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 500000000
 SYNC_RELOAD = 1
 
@@ -122,7 +122,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 1005000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 1000000000
 SYNC_RELOAD = 1
 
@@ -134,7 +134,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 1505000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 1500000000
 SYNC_RELOAD = 1
 
@@ -146,7 +146,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 2005000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 2000000000
 SYNC_RELOAD = 1
 
@@ -158,7 +158,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 2505000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 2500000000
 SYNC_RELOAD = 1
 
@@ -170,7 +170,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 3005000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 3000000000
 SYNC_RELOAD = 1
 
@@ -182,7 +182,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 3505000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 3500000000
 SYNC_RELOAD = 1
 
@@ -194,7 +194,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 4005000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 4000000000
 SYNC_RELOAD = 1
 
@@ -206,7 +206,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 4505000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 4500000000
 SYNC_RELOAD = 1
 
@@ -218,7 +218,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 5005000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 5000000000
 SYNC_RELOAD = 1
 
@@ -230,7 +230,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 5505000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 5500000000
 SYNC_RELOAD = 1
 
@@ -242,7 +242,7 @@ save_markers = markers.log
 [SCPI]
 tx.freq = 6000000000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = 5995000000
 SYNC_RELOAD = 1
 

--- a/profiles/FMComms2_test.ini
+++ b/profiles/FMComms2_test.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 startup_version_check=0
 test=1
 
@@ -61,12 +61,12 @@ test.ad7291.in_voltage5_raw.int = 1231 1393
 # in_voltage6 and 7 aren't connected
 # if we got here, all the supplies seem to be working well.
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 # force the right clock output mode
 debug.ad9361-phy.adi,clk-output-mode-select = 1
 debug.ad9361-phy.initialize = 1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = nominal
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920
@@ -126,7 +126,7 @@ SYNC_RELOAD = 1
 # wait for device to settle
 cycle = 3000
 
-[FMComms2/3/4]
+[AD936X]
 # channels should be off, so RSSI should be low
 test.ad9361-phy.in_voltage0_rssi.int = 75 150
 test.ad9361-phy.in_voltage1_rssi.int = 75 150
@@ -145,7 +145,7 @@ SYNC_RELOAD = 1
 # wait for device to settle
 cycle = 3000
 
-[FMComms2/3/4]
+[AD936X]
 # channels should be on, so RSSI should be high
 test.ad9361-phy.in_voltage0_rssi.int = 10 50
 test.ad9361-phy.in_voltage1_rssi.int = 10 50

--- a/profiles/FMComms4_sweep.ini
+++ b/profiles/FMComms4_sweep.ini
@@ -30,12 +30,12 @@ marker.7 = 8715
 marker.8 = 193
 marker.9 = 8625
 capture_started = 1
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 debug.ad9361-phy.adi,agc-adc-large-overload-exceed-counter = 10
 debug.ad9361-phy.adi,agc-adc-large-overload-inc-steps = 2
 debug.ad9361-phy.adi,agc-adc-lmt-small-overload-prevent-gain-inc-enable = 0
@@ -160,7 +160,7 @@ device_list = ad9361-phy 0
 device_list = xadc 0
 running = No
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = nominal
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920
@@ -220,7 +220,7 @@ SYNC_RELOAD = 1
 # sweep from 2300 to 2500 in 5 MHz steps
 
 <SEQ> i 2300000000 5000000 2500000000
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage0_RX_LO_frequency = <i>
 ad9361-phy.out_altvoltage1_TX_LO_frequency = <i>
 SYNC_RELOAD = 1

--- a/profiles/FMComms4_test.ini
+++ b/profiles/FMComms4_test.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 startup_version_check=0
 test=1
 
@@ -59,12 +59,12 @@ test.ad7291.in_voltage5_raw.int = 1231 1393
 # in_voltage6 and 7 aren't connected
 # if we got here, all the supplies seem to be working well.
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 # force the right clock output mode
 debug.ad9361-phy.adi,clk-output-mode-select = 1
 debug.ad9361-phy.initialize = 1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = nominal
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920
@@ -103,7 +103,7 @@ cf-ad9361-dds-core-lpc.out_altvoltage3_TX1_Q_F2_raw = 0
 cf-ad9361-dds-core-lpc.out_altvoltage3_TX1_Q_F2_scale = 0.062500
 SYNC_RELOAD = 1
 
-[FMComms2/3/4]
+[AD936X]
 #channels should be off, so RSSI should be low
 test.ad9361-phy.in_voltage0_rssi.int = 80 150
 
@@ -155,7 +155,7 @@ test.marker.3 = -100.0 -60.0
 capture_started = 0
 cycle = 1000
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.in_voltage0_rf_port_select = B_BALANCED
 ad9361-phy.out_voltage0_rf_port_select = B
 ad9361-phy.out_altvoltage1_TX_LO_frequency = 1400000000

--- a/profiles/FMComms5_test.ini
+++ b/profiles/FMComms5_test.ini
@@ -1,5 +1,5 @@
 [IIO Oscilloscope]
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
 plugin.FMComms5.detached=0
@@ -73,7 +73,7 @@ test.ad7291.in_voltage6_raw.int = 1140 1507
 test.ad7291.in_voltage7_raw.int = 1140 1507
 # if we got here, all the supplies seem to be working well.
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 # force the right clock output mode
 debug.ad9361-phy.adi,clk-output-mode-select = 1
 debug.ad9361-phy.initialize = 1
@@ -236,7 +236,7 @@ test.ad9361-phy-B.in_voltage1_hardwaregain.double = 0.0 28.0
 # save clock rate to eeprom
 dcxo_to_eeprom = 1
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 calibrate = 1
 
 [IIO Oscilloscope - Capture Window1]
@@ -343,7 +343,7 @@ ad9361-phy.out_altvoltage0_RX_LO_external = 0
 ad9361-phy-B.out_altvoltage1_TX_LO_external = 0
 ad9361-phy-B.out_altvoltage0_RX_LO_external = 0
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 calibrate = 1
 
 [IIO Oscilloscope - Capture Window1]

--- a/profiles/GSM.ini
+++ b/profiles/GSM.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 
 [IIO Oscilloscope - Capture Window1]
 domain=fft
@@ -23,7 +23,7 @@ cf-ad9361-lpc.in_voltage2.enabled=0
 cf-ad9361-lpc.in_voltage3.enabled=0
 capture_started=1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = highest_osr
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920

--- a/profiles/LTE10.ini
+++ b/profiles/LTE10.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 
 [IIO Oscilloscope - Capture Window1]
 domain=fft
@@ -23,7 +23,7 @@ cf-ad9361-lpc.in_voltage2.enabled=0
 cf-ad9361-lpc.in_voltage3.enabled=0
 capture_started=1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = nominal
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920

--- a/profiles/LTE15.ini
+++ b/profiles/LTE15.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 
 [IIO Oscilloscope - Capture Window1]
 domain=fft
@@ -23,7 +23,7 @@ cf-ad9361-lpc.in_voltage2.enabled=0
 cf-ad9361-lpc.in_voltage3.enabled=0
 capture_started=1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = nominal
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920

--- a/profiles/LTE1p4.ini
+++ b/profiles/LTE1p4.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 
 [IIO Oscilloscope - Capture Window1]
 domain=fft
@@ -23,7 +23,7 @@ cf-ad9361-lpc.in_voltage2.enabled=0
 cf-ad9361-lpc.in_voltage3.enabled=0
 capture_started=1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = nominal
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920

--- a/profiles/LTE20.ini
+++ b/profiles/LTE20.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 
 [IIO Oscilloscope - Capture Window1]
 domain=fft
@@ -23,7 +23,7 @@ cf-ad9361-lpc.in_voltage2.enabled=0
 cf-ad9361-lpc.in_voltage3.enabled=0
 capture_started=1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = nominal
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920

--- a/profiles/LTE3.ini
+++ b/profiles/LTE3.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 
 [IIO Oscilloscope - Capture Window1]
 domain=fft
@@ -23,7 +23,7 @@ cf-ad9361-lpc.in_voltage2.enabled=0
 cf-ad9361-lpc.in_voltage3.enabled=0
 capture_started=1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = nominal
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920

--- a/profiles/LTE5.ini
+++ b/profiles/LTE5.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 
 [IIO Oscilloscope - Capture Window1]
 domain=fft
@@ -23,7 +23,7 @@ cf-ad9361-lpc.in_voltage2.enabled=0
 cf-ad9361-lpc.in_voltage3.enabled=0
 capture_started=1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.trx_rate_governor = nominal
 ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920

--- a/profiles/PZSDR1_test.ini
+++ b/profiles/PZSDR1_test.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 test=1
 
 [IIO Oscilloscope - Capture Window1]
@@ -58,12 +58,12 @@ running = No
 ## in_voltage6 and 7 aren't connected
 ## if we got here, all the supplies seem to be working well.
 
-#[FMComms2/3/4/5 Advanced]
+#[AD936X Advanced]
 # force the right clock output mode
 #debug.ad9361-phy.adi,clk-output-mode-select = 1
 #debug.ad9361-phy.initialize = 1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.in_voltage0_rf_port_select = A_BALANCED
 ad9361-phy.out_voltage0_rf_port_select = A
 
@@ -105,7 +105,7 @@ cf-ad9361-dds-core-lpc.out_altvoltage3_TX1_Q_F2_raw = 0
 cf-ad9361-dds-core-lpc.out_altvoltage3_TX1_Q_F2_scale = 0.062500
 SYNC_RELOAD = 1
 
-[FMComms2/3/4]
+[AD936X]
 # channels should be off, so RSSI should be low
 test.ad9361-phy.in_voltage0_rssi.int = 80 150
 

--- a/profiles/PZSDR2_2400TDD_test.ini
+++ b/profiles/PZSDR2_2400TDD_test.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
 plugin.Spectrum Analyzer.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 window_x_pos=66
 window_y_pos=46
@@ -79,7 +79,7 @@ marker.0 = 5494
 marker.1 = 10767
 capture_started=0
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 debug.ad9361-phy.adi,txmon-2-lo-cm = 48
 debug.ad9361-phy.adi,txmon-1-lo-cm = 48
 debug.ad9361-phy.adi,txmon-2-front-end-gain = 2
@@ -234,7 +234,7 @@ debug.ad9361-phy.adi,ensm-enable-pin-pulse-mode-enable = 0
 debug.ad9361-phy.adi,frequency-division-duplex-mode-enable = 1
 debug.ad9361-phy.initialize=1
 
-[FMComms2/3/4]
+[AD936X]
 # load filter LTE20_MHz.ftr
 load_fir_filter_file = /usr/local/lib/osc/filters/LTE20_MHz.ftr
 ad9361-phy.out_altvoltage1_TX_LO_frequency = 2400000000
@@ -361,7 +361,7 @@ marker.3 = 15616
 marker.4 = 12629
 capture_started=0
 
-[FMComms2/3/4]
+[AD936X]
 # set TX/RX LO to 2.4GHz, TX tone to 5.6MHz, TX scale to -30dB, TX attenuation to -10dB, RX to manual gain and set to 20dB
 ad9361-phy.out_altvoltage1_TX_LO_frequency = 2400000000
 ad9361-phy.out_altvoltage1_TX_LO_external = 0
@@ -501,7 +501,7 @@ test.marker.4 = -120.0 -50.0
 capture_started = 0
 
 
-[FMComms2/3/4]
+[AD936X]
 # test TX_MONITOR2 for channel 2
 ad9361-phy.in_voltage0_rf_port_select = TX_MONITOR2
 SYNC_RELOAD = 1
@@ -532,7 +532,7 @@ cf-ad9361-lpc.voltage3.enabled=0
 cycle = 1000
 
 
-[FMComms2/3/4]
+[AD936X]
 # test TX_MONITOR1 for channel 1
 ad9361-phy.in_voltage0_rf_port_select = TX_MONITOR1
 
@@ -561,7 +561,7 @@ marker.0 = 5494
 marker.1 = 10767
 capture_started=0
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 debug.ad9361-phy.adi,txmon-2-lo-cm = 48
 debug.ad9361-phy.adi,txmon-1-lo-cm = 48
 debug.ad9361-phy.adi,txmon-2-front-end-gain = 2
@@ -716,7 +716,7 @@ debug.ad9361-phy.adi,ensm-enable-pin-pulse-mode-enable = 0
 debug.ad9361-phy.adi,frequency-division-duplex-mode-enable = 1
 debug.ad9361-phy.initialize=1
 
-[FMComms2/3/4]
+[AD936X]
 # load filter LTE20_MHZ.ftr
 load_fir_filter_file = /usr/local/lib/osc/filters/LTE20_MHz.ftr
 ad9361-phy.out_altvoltage1_TX_LO_frequency = 2400000000
@@ -835,7 +835,7 @@ test.marker.0 = -120.0 -80.0
 test.marker.1 = -120.0 -80.0
 capture_started=0
 
-[FMComms2/3/4]
+[AD936X]
 # set TX/RX LO to 2.4GHz, TX tone to 5.6MHz, TX scale to -20dB, TX attenuation to -10dB, RX to manual gain and set to 20dB
 ad9361-phy.out_altvoltage1_TX_LO_frequency = 2400000000
 ad9361-phy.out_altvoltage1_TX_LO_external = 0
@@ -983,14 +983,14 @@ test.marker.4 = -120.0 -50.0
 capture_started = 0
 cycle = 1000
 
-[FMComms2/3/4/5 Advanced]
+[AD936X Advanced]
 # set low GPO0/1
 debug.ad9361-phy.adi,gpo-manual-mode-enable-mask = 4
 # enable GPO manual mode control
 debug.ad9361-phy.adi,gpo-manual-mode-enable = 1
 debug.ad9361-phy.initialize=1
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.out_altvoltage1_TX_LO_frequency = 2400000000
 ad9361-phy.out_altvoltage1_TX_LO_external = 0
 ad9361-phy.out_voltage_rf_bandwidth = 18000000

--- a/profiles/PZSDR2_test.ini
+++ b/profiles/PZSDR2_test.ini
@@ -1,8 +1,8 @@
 [IIO Oscilloscope]
-plugin.FMComms2/3/4/5 Advanced.detached=0
+plugin.AD936X Advanced.detached=0
 plugin.DMM.detached=0
 plugin.Debug.detached=0
-plugin.FMComms2/3/4.detached=0
+plugin.AD936X.detached=0
 startup_version_check=0
 test=1
 
@@ -61,7 +61,7 @@ running = No
 ## in_voltage6 and 7 aren't connected
 ## if we got here, all the supplies seem to be working well.
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.in_voltage0_rf_port_select = A_BALANCED
 ad9361-phy.out_voltage0_rf_port_select = A
 
@@ -124,7 +124,7 @@ SYNC_RELOAD = 1
 # wait for device to settle
 cycle = 3000
 
-[FMComms2/3/4]
+[AD936X]
 # channels should be off, so RSSI should be low
 test.ad9361-phy.in_voltage0_rssi.int = 75 150
 test.ad9361-phy.in_voltage1_rssi.int = 75 150
@@ -143,7 +143,7 @@ SYNC_RELOAD = 1
 # wait for device to settle
 cycle = 3000
 
-[FMComms2/3/4]
+[AD936X]
 # channels should be on, so RSSI should be high
 test.ad9361-phy.in_voltage0_rssi.int = 10 60
 test.ad9361-phy.in_voltage1_rssi.int = 10 60
@@ -190,7 +190,7 @@ test.marker.3 = -110.0 -70.0
 # 4th Harmonic
 test.marker.4 = -110.0 -80.0
 
-[FMComms2/3/4]
+[AD936X]
 ad9361-phy.in_voltage0_rf_port_select = B_BALANCED
 ad9361-phy.out_voltage0_rf_port_select = B
 ad9361-phy.out_altvoltage1_TX_LO_frequency = 1400000000
@@ -216,7 +216,7 @@ SYNC_RELOAD = 1
 # wait for device to settle
 cycle = 3000
 
-[FMComms2/3/4]
+[AD936X]
 # channels should be on, so RSSI should be high
 test.ad9361-phy.in_voltage0_rssi.int = 10 60
 test.ad9361-phy.in_voltage1_rssi.int = 10 60


### PR DESCRIPTION
Rename FMComms2 tabs to AD936X to address #147. Test ini files have been updated as well with this new naming.

Signed-off-by: Travis Collins <travis.collins@analog.com>