### PR TITLE
Fix gksu deprecated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,12 @@ install(TARGETS oscmain RUNTIME DESTINATION bin)
 # Set default CMAKE_PREFIX_PATH to CMAKE_SYSTEM_PREFIX_PATH
 set(CMAKE_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH})
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	configure_file(org.adi.pkexec.osc.policy.cmakein ${CMAKE_CURRENT_BINARY_DIR}/org.adi.pkexec.osc.policy @ONLY)
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.adi.pkexec.osc.policy
+		DESTINATION /usr/share/polkit-1/actions/)
+endif()
+
 set(PLIB_DEST lib/osc)
 set(SHARE_DEST share/osc)
 set(GLADE_FILES_DEST ${SHARE_DEST}/glade)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,12 @@ file(GLOB ICON_FILES icons/*)
 
 install(FILES ${GLADE_FILES} ${ICON_FILES} DESTINATION ${SHARE_DEST})
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	configure_file(adi-osc.desktop.cmakein ${CMAKE_CURRENT_BINARY_DIR}/adi-osc.desktop @ONLY)
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/adi-osc.desktop
+		DESTINATION /usr/share/applications/)
+endif()
+
 install(DIRECTORY icons DESTINATION ${SHARE_DEST})
 
 foreach(plib_dest xmls filters waveforms profiles block_diagrams)

--- a/adi-osc.desktop.cmakein
+++ b/adi-osc.desktop.cmakein
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Exec=pkexec @CMAKE_INSTALL_PREFIX@/bin/osc
+Icon=@CMAKE_INSTALL_PREFIX@/@SHARE_DEST@/icons/osc.svg
+Terminal=false
+Type=Application
+Categories=Science
+Name=ADI IIO Oscilloscope
+GenericName=ADI IIO Oscilloscope

--- a/org.adi.pkexec.osc.policy.cmakein
+++ b/org.adi.pkexec.osc.policy.cmakein
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN" "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <vendor>Analog Devices Inc.</vendor>
+  <vendor_url>https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope</vendor_url>
+  <icon_name>adi-osc</icon_name>
+  <action id="org.adi.pkexec.osc">
+    <description>The ADI IIO Oscilloscope is a example application, which demonstrates how to interface different evaluation boards from within a Linux system.</description>
+    <message>Authentication is required to run osc</message>
+    <defaults>
+      <allow_any>auth_admin_keep</allow_any>
+      <allow_inactive>auth_admin_keep</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">@CMAKE_INSTALL_PREFIX@/bin/osc</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
+</policyconfig>


### PR DESCRIPTION
This PR aims to fix #102. It also configures and installs an adi-osc.desktop file when using cmake. Also note that, the polkit action is only being supported on cmake builds.... 