### PR TITLE
CI/travis: fix build with OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,8 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./CI/travis/before_install_darwin ; fi
 
 script:
-  - ${TRAVIS_BUILD_DIR}/CI/travis/make_linux "$OS_TYPE" "$OS_VERSION"
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ${TRAVIS_BUILD_DIR}/CI/travis/make_linux "$OS_TYPE" "$OS_VERSION" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ${TRAVIS_BUILD_DIR}/CI/travis/make_darwin ; fi
   - ${TRAVIS_BUILD_DIR}/CI/travis/post_build_checks
 
 notifications:

--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -1,0 +1,5 @@
+#!/bin/sh -xe
+
+export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
+
+. CI/travis/make_linux

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -14,7 +14,7 @@ handle_default() {
 		cmake ..
 		make
 	else
-		export PKG_CONFIG_PATH="$STAGINGDIR/lib/pkgconfig" ; \
+		export PKG_CONFIG_PATH="$STAGINGDIR/lib/pkgconfig:$PKG_CONFIG_PATH" ; \
 		cmake -DCMAKE_PREFIX_PATH="$STAGINGDIR" -DCMAKE_INSTALL_PREFIX="$STAGINGDIR" \
 			-DCMAKE_EXE_LINKER_FLAGS="-L${STAGINGDIR}/lib" ..
 		CFLAGS=-I${STAGINGDIR}/include LDFLAGS=-L${STAGINGDIR}/lib make


### PR DESCRIPTION
Error is:
```
--   Package 'libffi', required by 'gobject-2.0', not found
CMake Error at /usr/local/Cellar/cmake/3.14.0/share/cmake/Modules/FindPkgConfig.cmake:457 (message):
```

Fix this by providing the correct PKG_CONFIG_PATH for libffi.

Also splitting a `make_darwin` file from `make_linux`.
This is to assign the MacOS X specific env-var to the build.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>