### PR TITLE
build: retire/remove trusty builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,11 @@ matrix:
   include:
     - compiler: clang
       os: linux
-      dist: trusty
       env:
         - TEST_NON_GIT_REPO=1
         - LDIST=DO_NOT_DEPLOY
     - compiler: gcc
       os: linux
-      dist: trusty
-    - compiler: gcc
-      os: linux
-      dist: xenial
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,14 @@ matrix:
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
+      # FIXME: remove dist, when Xenial images become default in Travis CI
+      dist: xenial
       env:
         - OS_TYPE=centos_docker
         - OS_VERSION=7
     - os: linux
+      # FIXME: remove dist, when Xenial images become default in Travis CI
+      dist: xenial
       env:
         - OS_TYPE=ubuntu_docker
         - OS_VERSION=bionic


### PR DESCRIPTION
Trusty is 5 years old now.
And since this year, Ubuntu Xenial 16.04 is the default in Travis-CI:
 https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>