### PR TITLE
Osc preferences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 set(OSC_SRC osc.c oscplot.c datatypes.c iio_widget.c iio_utils.c
 	fru.c dialogs.c trigger_dialog.c xml_utils.c libini/libini.c
 	libini2.c phone_home.c plugins/dac_data_manager.c
-	plugins/fir_filter.c eeprom.c)
+	plugins/fir_filter.c eeprom.c osc_preferences.c)
 
 find_package(PkgConfig)
 pkg_check_modules(GLIB REQUIRED glib-2.0)

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ endif
 
 OSC_OBJS := osc.o oscplot.o datatypes.o iio_widget.o fru.o dialogs.o \
 	trigger_dialog.o xml_utils.o libini/libini.o libini2.o phone_home.o \
-	plugins/dac_data_manager.o plugins/fir_filter.o iio_utils.o \
+	plugins/dac_data_manager.o plugins/fir_filter.o iio_utils.o osc_preferences.o \
 	$(if $(WITH_MINGW),,eeprom.o)
 
 all: $(OSC) $(PLUGINS)
@@ -157,6 +157,7 @@ oscicon.o: oscicon.rc
 
 # Dependencies
 iio_utils.o: iio_utils.h
+osc_preferences.o: osc_preferences.h
 osc.o: iio_widget.h osc_plugin.h osc.h libini2.h
 oscmain.o: config.h osc.h
 oscplot.o: oscplot.h osc.h datatypes.h iio_widget.h libini2.h

--- a/osc_plugin.h
+++ b/osc_plugin.h
@@ -8,6 +8,8 @@
 #ifndef __OSC_PLUGIN_H__
 #define __OSC_PLUGIN_H__
 
+#include "osc_preferences.h"
+
 #include <gtk/gtk.h>
 
 /* Information needed to create a new plugin */
@@ -29,6 +31,7 @@ struct osc_plugin {
 	int (*handle_external_request) (struct osc_plugin *plugin, const char *request);
 	void (*update_active_page)(struct osc_plugin *plugin, gint active_page, gboolean is_detached);
 	void (*get_preferred_size)(const struct osc_plugin *plugin, int *width, int *size);
+	OscPreferences* (*get_preferences_for_osc)(const struct osc_plugin *plugin);
 	void (*destroy)(struct osc_plugin *plugin, const char *ini_fn);
 
 	void (*save_profile)(const struct osc_plugin *plugin, const char *ini_fn);

--- a/osc_preferences.c
+++ b/osc_preferences.c
@@ -1,0 +1,71 @@
+#include "osc_preferences.h"
+
+/* IioChnPreferences */
+
+ IioChnPreferences* iio_chn_preferences_new(const char *chn_name)
+{
+        IioChnPreferences *chn_pref = g_new0(IioChnPreferences, 1);
+
+        chn_pref->chn_name = g_strdup(chn_name);
+
+        return chn_pref;
+}
+
+ void iio_chn_preferences_free(IioChnPreferences *pref)
+{
+        g_free(pref->chn_name);
+        pref->chn_name = NULL;
+}
+
+/* IioDevPreferences */
+
+ IioDevPreferences* iio_dev_preferences_new(const char *dev_name)
+{
+        IioDevPreferences *dev_pref = g_new0(IioDevPreferences, 1);
+
+        dev_pref->dev_name = g_strdup(dev_name);
+
+        return dev_pref;
+}
+
+ void iio_dev_preferences_free(IioDevPreferences *pref)
+{
+        g_free(pref->dev_name);
+        pref->dev_name = NULL;
+
+        g_free(pref->fft_correction);
+        pref->fft_correction = NULL;
+
+        g_list_free_full(pref->channels_pref_list,
+                (GDestroyNotify)iio_chn_preferences_free);
+}
+
+/* OscPlotPreferences */
+
+ OscPlotPreferences* osc_plot_preferences_new()
+{
+        return g_new0(OscPlotPreferences, 1);
+}
+
+ void osc_plot_preferences_free(OscPlotPreferences *pref)
+{
+        g_free(pref->sample_count);
+        pref->sample_count = NULL;
+
+        g_list_free_full(pref->devices_pref_list,
+                (GDestroyNotify)iio_dev_preferences_free);
+}
+
+/* OscPreferences */
+
+ OscPreferences* osc_preferences_new()
+{
+        return g_new0(OscPreferences, 1);
+}
+
+ void osc_preferences_delete(OscPreferences *pref)
+{
+        if (pref->plot_preferences) {
+                osc_plot_preferences_free(pref->plot_preferences);
+        }
+}

--- a/osc_preferences.h
+++ b/osc_preferences.h
@@ -1,0 +1,46 @@
+#ifndef __OSC_PREFERENCES_H__
+#define __OSC_PREFERENCES_H__
+
+#include <glib.h>
+
+typedef struct osc_preferences OscPreferences;
+typedef struct oscplot_preferences OscPlotPreferences;
+typedef struct iio_device_preferences IioDevPreferences;
+typedef struct iio_channel_preferences IioChnPreferences;
+
+struct oscplot_preferences {
+        unsigned int *sample_count;
+        GList *devices_pref_list;
+};
+
+struct iio_channel_preferences {
+        char *chn_name;
+        unsigned int *constraints;
+};
+
+struct iio_device_preferences {
+        char *dev_name;
+        double *fft_correction;
+        GList *channels_pref_list;
+};
+
+struct osc_preferences {
+        struct oscplot_preferences *plot_preferences;
+};
+
+
+/* Construct/Destruct methods */
+
+IioChnPreferences* iio_chn_preferences_new(const char *chn_name);
+void iio_chn_preferences_free(IioChnPreferences *pref);
+
+IioDevPreferences* iio_dev_preferences_new(const char *dev_name);
+void iio_dev_preferences_free(IioDevPreferences *pref);
+
+OscPlotPreferences* osc_plot_preferences_new();
+void osc_plot_preferences_free(OscPlotPreferences *pref);
+
+OscPreferences* osc_preferences_new();
+void osc_preferences_delete(OscPreferences *pref);
+
+#endif /* __OSC_PREFERENCES_H__ */

--- a/oscplot.h
+++ b/oscplot.h
@@ -7,6 +7,8 @@
 #ifndef __OSC_PLOT__
 #define __OSC_PLOT__
 
+#include "osc_preferences.h"
+
 #include <glib.h>
 #include <glib-object.h>
 #include <gtk/gtkwindow.h>
@@ -40,6 +42,7 @@ struct _OscPlotClass
 
 GType         osc_plot_get_type         (void);
 GtkWidget*    osc_plot_new              (struct iio_context *ctx);
+GtkWidget*    osc_plot_new_with_pref    (struct iio_context *ctx, OscPlotPreferences* pref);
 void          osc_plot_destroy          (OscPlot *plot);
 void          osc_plot_set_visible      (OscPlot *plot, bool visible);
 struct iio_buffer * osc_plot_get_buffer (OscPlot *plot);

--- a/plugins/fmcomms2.c
+++ b/plugins/fmcomms2.c
@@ -1999,7 +1999,7 @@ static GtkWidget * fmcomms2_init(struct osc_plugin *plugin, GtkWidget *notebook,
 	adc_dev = iio_context_find_device(get_context_from_osc(), CAP_DEVICE);
 	if (adc_dev) {
 		adc_info = iio_device_get_data(adc_dev);
-		if (adc_info)
+		if (adc_info) /* TO DO: use osc preferences instead */
 			adc_info->plugin_fft_corr = 20 * log10(1/sqrt(HANNING_ENBW));
 	}
 

--- a/plugins/lidar.c
+++ b/plugins/lidar.c
@@ -378,6 +378,19 @@ static void lidar_get_preferred_size(const struct osc_plugin *plugin,
 		*height = 480;
 }
 
+static OscPreferences* lidar_get_preferences_for_osc(const struct osc_plugin *plugin)
+{
+	OscPreferences *pref = osc_preferences_new();
+
+	pref->plot_preferences = osc_plot_preferences_new();
+	pref->plot_preferences->sample_count = g_new(unsigned int, 1);
+	*pref->plot_preferences->sample_count = 1024;
+
+	/* TO DO: add here the preferences about channel voltage4 */
+
+	return pref;
+}
+
 static bool lidar_identify(const struct osc_plugin *plugin)
 {
 	/* Use the OSC's IIO context just to detect the devices */
@@ -392,5 +405,6 @@ struct osc_plugin plugin = {
 	.init = lidar_init,
 	.update_active_page = update_active_page,
 	.get_preferred_size = lidar_get_preferred_size,
+	.get_preferences_for_osc = lidar_get_preferences_for_osc,
 	.destroy = context_destroy,
 };


### PR DESCRIPTION
Add a system for the plugins to send their preferences to the osc and the osc plot.
The idea is to have a straight forward way to exchange this kind of data.
All preferences are collected by osc and merged (if no conflicts). Then the preferences are use throughout the application.
Examples of preferences:
 - default value of sample count when creating a plot window
 - constraints for some channels to be always checked in the plot window
 - constraints for some channels to be un-toggleable in the plot window
 - additional FFT correction to be used for a specific iio-device
Other preferences might come up in the future