### PR TITLE
oscplot: Fix message that says correlation needs 2 channels (needs 4)

### DIFF
--- a/oscplot.c
+++ b/oscplot.c
@@ -2055,7 +2055,7 @@ static gboolean check_valid_setup_of_device(OscPlot *plot, const char *name)
 	} else if (plot_type == XCORR_PLOT) {
 		if (enabled_channels_count(plot) != 4) {
 			gtk_widget_set_tooltip_text(priv->capture_button,
-				"Correlation requires 2 or 4 channels");
+				"Correlation requires 4 channels");
 			return false;
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Dan Nechita <dan.nechita@analog.com>