### PR TITLE
build,os-x: ignore deprecated warnings

### DIFF
--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -2,4 +2,6 @@
 
 export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
 
+export CFLAGS="-Wno-deprecated"
+
 . CI/travis/make_linux


### PR DESCRIPTION
OS X's glib is upgrading way too fast/often.
Now it's complaining with some deprecation stuff.
Export a CFLAGS option to ignore this.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>