### PR TITLE
build,travis-c: update build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,10 @@ matrix:
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
-      # FIXME: remove dist, when Xenial images become default in Travis CI
-      dist: xenial
       env:
         - OS_TYPE=centos_docker
         - OS_VERSION=7
     - os: linux
-      # FIXME: remove dist, when Xenial images become default in Travis CI
-      dist: xenial
       env:
         - OS_TYPE=ubuntu_docker
         - OS_VERSION=bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,11 @@ matrix:
       osx_image: xcode10.1
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
+    - compiler: "gcc"
+      os: osx
+      osx_image: xcode11
+      env:
+        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
 
 addons:
   artifacts: true

--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -1,6 +1,16 @@
 #!/bin/sh -e
 
-export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
+PKG_CONFIG_LIBS="libffi libxml2 glib"
+
+for lib in $PKG_CONFIG_LIBS ; do
+	if [ -z "$PKG_CONFIG_PATH" ] ; then
+		PKG_CONFIG_PATH="/usr/local/opt/$lib/lib/pkgconfig"
+	else
+		PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:/usr/local/opt/$lib/lib/pkgconfig"
+	fi
+done
+
+export PKG_CONFIG_PATH
 
 export CFLAGS="-Wno-deprecated"
 


### PR DESCRIPTION
1. Add support for Xcode 11 (implicitly also for Mac OS Mojave)
2. Reverts patch .travis.yml: force xenial for docker builds ; Xenial images should be the default now (hopefully); removing this limitation let's Travis-CI upgrade the default docker image (since Xenial is the minimum we need).
Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>