### PR TITLE
build,travis-ci: drop support for Xcode 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,6 @@ matrix:
         - OS_VERSION=bionic
     - compiler: "gcc"
       os: osx
-      osx_image: xcode9.2
-      env:
-        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
-    - compiler: "gcc"
-      os: osx
       osx_image: xcode10.1
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss


### PR DESCRIPTION
iio-oscilloscope does not have any relation (directly & dependency-wise) to
Matlab (or other Mathworks tools).

So, we can choose to drop support for Xcode 9 now.
Since support for Xcode 11 has been recently added, it's probably a good
idea to also remove support for Xcode 9.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>