### PR TITLE
plugins/dac_data_manager: Don't overwrite already initialized things

### DIFF
--- a/plugins/dac_data_manager.c
+++ b/plugins/dac_data_manager.c
@@ -1917,12 +1917,12 @@ static int dds_dac_init(struct dac_data_manager *manager,
 			"with %u number of tones\n", ddac->tones_count);
 			return -1;
 		}
-	}
-
-	ddac->txs = calloc(tx_count, sizeof(struct dds_tx));
-	guint tx = 0;
-	for (; tx < tx_count; tx++) {
-		dds_tx_init(ddac, &ddac->txs[tx], tx + 1);
+	} else {
+		ddac->txs = calloc(tx_count, sizeof(struct dds_tx));
+		guint tx = 0;
+		for (; tx < tx_count; tx++) {
+			dds_tx_init(ddac, &ddac->txs[tx], tx + 1);
+		}
 	}
 
 	manager->dacs_count++;


### PR DESCRIPTION
The generic initialization of ddac->txs overwrites the other one which is made in the special case when tx_count == 0.
This fixes segfault when loading FMComms11 and most likely Ad9739A (and any other board that matches the special case consiguration where tx_count == 0).

Signed-off-by: Dan Nechita <dan.nechita@analog.com>