### PR TITLE
Fix comboboxtext issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ addons:
     secure: "HzU57pX/0iwRgPCnrP7QQ92XkrySsx/jjCLEqNAyWuQBYTMl2vVXnys7dclUp841CWRHv3TQXT0Jem9mZ9oZbzMR8Nxo2mjJyiH06BMcBYmTiaGxzSOh0XjiYTm3ZZvH+SQYdiXNBbPIY7B1ekC6Vw/ZQ8N4U1SiMh5W38+jXgqTYefB2h8GjmYB8f3DP0WE97ITaLG0/dUF+vLkuyJaLHND2j0e+cjjir8ah8eioK67+iX1dnDnN4U6su7tdVcqHGdgS3sSjvFl8+q9R9IFuT2RuQLd05Fu5gehV5ruJP0GzjJ8eU1fhkFSiWPenBGgkDRsv7ORmtL9ZmZKjtXIxhIlgVBdH8Rb9qtDCbKf6tSSrOU14TkN1FR8uPw68xhlnptS31AwB+OisWw1ULRJBEWRTABw+avUloDhgFMgUtFnSukjMlst16Qwq5bGKn5yQ6KBJU8BP/uX6ptGQemTokEe92TWJq6TS6kNpb8rA537gaMp8VQ2zk8Nhw6LovA5LbuKB73rcjuQsOto2/DF2GhJkBQ0peVzu1vsAFD5WmMTPzQziTLiTyI+gQktYJSoV8ERAvxqeDptqUYMrRMg7VtuV5fNEQ2Q5fVMrcqB9NGkeUjfIo7GHP0tBEzLCNjaRNYrMxEqKYW8OQSfINA3b3gLZuwLepHW71j2xqnFlpQ="
 
 before_install:
+  - ${TRAVIS_BUILD_DIR}/CI/travis/pre_build_checks
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./CI/travis/before_install_linux "$OS_TYPE" "$OS_VERSION" ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./CI/travis/before_install_darwin ; fi
 

--- a/CI/travis/pre_build_checks
+++ b/CI/travis/pre_build_checks
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+echo_error() { printf "\033[1;31m$*\033[m\n"; }
+
+pushd dev-tools
+./fixup-all-glades.sh fixup-comboboxtext.pl
+popd
+
+if [[ $(git status --porcelain --untracked-files=no) ]]; then
+        echo_error "Every time a glade is edited with Glade editor for GTK3 (versions 3.9, 3.10, 3.11, etc.) the fixup scripts from dev-tools need to be run for the modified glade file."
+fi

--- a/NOTE_FOR_DEVELOPERS.txt
+++ b/NOTE_FOR_DEVELOPERS.txt
@@ -1,0 +1,1 @@
+1. Every time a glade is edited with Glade editor for GTK3 (versions 3.9, 3.10, 3.11, etc.) the fixup scripts from dev-tools need to be run for the modified glade file. However if Glade 3.8 is used the fixup scripts are no longer required.

--- a/dev-tools/fixup-all-glades.sh
+++ b/dev-tools/fixup-all-glades.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Execute the fixer script (which is should be passed as the first argument)
+# for all glade files in this repo
+
+if [ $1 = "" ]; then
+        echo "You need to pass a fixer"
+        exit
+fi
+
+for file in ../glade/*.glade; do
+        eval "./$1 $file"
+done

--- a/dev-tools/fixup-comboboxtext.pl
+++ b/dev-tools/fixup-comboboxtext.pl
@@ -1,0 +1,73 @@
+#!/usr/bin/perl
+
+# The problem:
+# GtkComboBoxText has a bug that makes it unsuable (can't get the active text,
+# or insert new text, etc.). In order to work, instances of GtkComboBoxText
+# need the property "entry-text-column" >= 0, which doesn't happen when a
+# GtkComboBoxText is obtained from a glade file (creating them with new works).
+
+# The solution:
+# This script adds the missing property of GtkComboBoxText objects that are
+# described in .glade file.
+
+# Usage:
+# ./fixup-comboboxtext.pl path_to_glade_file 
+
+# Note: this script can be passed to fixup-all-glades.sh to go through all
+# glade files in this repo.
+
+use strict;
+
+my $fileToFix = $ARGV[0];
+my $tmpFileToRead = $fileToFix.'.bak';
+
+rename($fileToFix, $tmpFileToRead) || die "Cannot rename file $fileToFix: $!";
+open my $inFile, '<', $tmpFileToRead or die "Can't read $tmpFileToRead: $!";
+open my $outFile, '>', $fileToFix or die "Can't write to file $fileToFix: $!";
+
+my $comboBoxTextDetected = 0;
+my $entryTextColumnDetected = 0;
+
+while( <$inFile> ) {
+        # Check if we're at a GtkComboBoxText definition.
+        if ($_ =~ m/<object class="GtkComboBoxText"/)
+        {
+                $comboBoxTextDetected = 1;
+        }
+
+        # Check if the GtkComboBoxText definition has property "entry_text_column" defined.
+        if ($comboBoxTextDetected && $_ =~ m/<property name="entry_text_column">/)
+        {
+                $entryTextColumnDetected = 1;
+        }
+
+        # We've reach the end of the object definition or the start if items definition.
+        # Add the "entry_text_column" is not already there. Reset things.
+        if ($comboBoxTextDetected && ($_ =~ m/<\/object>/ || $_ =~ m/<items>/))
+        {
+                # Find indentation for </object>
+                $_ =~ m/(\s+)(<.+>)/;
+                my $indentation = $1;
+
+                # Increase indentation with 2 spaces
+                if ($2 eq "</object>")
+                {
+                        $indentation .="  ";
+                }
+
+                if (!$entryTextColumnDetected)
+                {
+                    print $outFile $indentation;
+                    print $outFile "<property name=\"entry_text_column\">0</property>\n";
+                }
+
+                $comboBoxTextDetected = 0;
+                $entryTextColumnDetected = 0;
+        }
+
+        print $outFile $_;
+}
+
+close $inFile;
+close $outFile;
+unlink($tmpFileToRead) || die "Cannont unlink $tmpFileToRead: $!";

--- a/dev-tools/fixup-gtk3-glade.sh
+++ b/dev-tools/fixup-gtk3-glade.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo Fixing This $1
+perl -pi -e 's/GtkGrid/GtkTable/g' $1
+perl -pi -e 's/GtkBox/GtkVBox/g' $1
+grep "<requires lib=" $1 && sed -i.tmp '4d' $1

--- a/glade/ad9371.glade
+++ b/glade/ad9371.glade
@@ -412,6 +412,7 @@
                                               <object class="GtkComboBoxText" id="ensm_mode_available">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="entry_text_column">0</property>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">1</property>
@@ -729,6 +730,7 @@
                                               <object class="GtkComboBoxText" id="gain_control_mode_available_rx1">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="entry_text_column">0</property>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">3</property>
@@ -3454,6 +3456,7 @@
                                               <object class="GtkComboBoxText" id="rf_port_select_obs">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="entry_text_column">0</property>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">3</property>
@@ -3645,6 +3648,7 @@
                                                           <object class="GtkComboBoxText" id="gain_control_mode_available_obs">
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">False</property>
+                                                            <property name="entry_text_column">0</property>
                                                           </object>
                                                           <packing>
                                                             <property name="left_attach">1</property>
@@ -3845,6 +3849,7 @@
                                                           <object class="GtkComboBoxText" id="fpga_tx_frequency_available">
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">False</property>
+                                                            <property name="entry_text_column">0</property>
                                                           </object>
                                                           <packing>
                                                             <property name="left_attach">1</property>
@@ -3960,6 +3965,7 @@
                                                             <object class="GtkComboBoxText" id="fpga_rx_frequency_available">
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">False</property>
+                                                              <property name="entry_text_column">0</property>
                                                             </object>
                                                             <packing>
                                                             <property name="left_attach">1</property>

--- a/glade/ad9371_adv.glade
+++ b/glade/ad9371_adv.glade
@@ -1159,6 +1159,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">CLKPLL VCO divider</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VCO DIV 1</item>
                           <item translatable="yes">VCO DIV 1.5</item>
@@ -1534,6 +1535,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Tx Attenuation step size</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">ATTEN STEP 0.05 dB</item>
                                       <item translatable="yes">ATTEN STEP 0.10 dB</item>
@@ -1597,6 +1599,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">The desired Tx channels to enable during initialization</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">OFF</item>
                                       <item translatable="yes">TX1</item>
@@ -1899,6 +1902,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">The TX digital FIR filter interpolation (1,2,4)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">INTERPOLATE by 1</item>
                                       <item translatable="yes">INTERPOLATE by 2</item>
@@ -1917,6 +1921,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">The divider used to generate the DAC clock (ENUM Values)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">DAC DIV 2</item>
                                       <item translatable="yes">DAC DIV 2.5</item>
@@ -3338,6 +3343,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">The desired Rx Channels to enable during initialization</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">OFF</item>
                                       <item translatable="yes">RX1</item>
@@ -3577,6 +3583,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Rx FIR decimation (1,2,4)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">DECIMATE by 1</item>
                                       <item translatable="yes">DECIMATE by 2</item>
@@ -3728,6 +3735,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Default ObsRx channel to enter when radioOn called</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">RXOFF</item>
                                       <item translatable="yes">RX1_TXLO</item>
@@ -3797,6 +3805,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">The sniffer/ORx mixers can use the TX_PLL or SNIFFER_PLL</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">OBSLO_TX_PLL</item>
                                       <item translatable="yes">OBSLO_SNIFFER_PLL</item>
@@ -4156,6 +4165,7 @@
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="tooltip_text" translatable="yes">Rx FIR decimation (1,2,4)</property>
+                                                <property name="entry_text_column">0</property>
                                                 <items>
                                                   <item translatable="yes">DECIMATE by 1</item>
                                                   <item translatable="yes">DECIMATE by 2</item>
@@ -4410,6 +4420,7 @@
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="tooltip_text" translatable="yes">Rx FIR decimation (1,2,4)</property>
+                                                <property name="entry_text_column">0</property>
                                                 <items>
                                                   <item translatable="yes">DECIMATE by 1</item>
                                                   <item translatable="yes">DECIMATE by 2</item>
@@ -4736,6 +4747,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Current Rx gain control mode setting</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">MGC</item>
                                       <item translatable="yes">AGC</item>
@@ -4907,6 +4919,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Current ORx gain control mode setting</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">MGC</item>
                                       <item translatable="yes">AGC</item>
@@ -5052,6 +5065,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Current Sniffer gain control mode setting</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">MGC</item>
                                       <item translatable="yes">AGC</item>
@@ -6685,6 +6699,7 @@ DETECT ENABLE</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="tooltip_text" translatable="yes">Power measurement configuration. 2-bit field. [00]=PMD disabled, [01]=PMD Enabled at HB2 output, [10]=Enabled at RFIR output (recommended), [11]=PMD Enabled at BBDC2</property>
+                                            <property name="entry_text_column">0</property>
                                             <items>
                                               <item translatable="yes">DISABLED</item>
                                               <item translatable="yes">HB2</item>
@@ -6938,6 +6953,7 @@ DETECT ENABLE</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="tooltip_text" translatable="yes">Power measurement configuration. 2-bit field. [00]=PMD disabled, [01]=PMD Enabled at HB2 output, [10]=Enabled at RFIR output (recommended), [11]=PMD Enabled at BBDC2</property>
+                                            <property name="entry_text_column">0</property>
                                             <items>
                                               <item translatable="yes">DISABLED</item>
                                               <item translatable="yes">HB2</item>
@@ -7886,6 +7902,7 @@ DETECT ENABLE</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Mode for GPIO3v3[11:8] pins</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">LEVELTRANSLATE_MODE</item>
                                       <item translatable="yes">INVLEVELTRANSLATE_MODE</item>
@@ -7905,6 +7922,7 @@ DETECT ENABLE</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Mode for GPIO3v3[7:4] pins</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">LEVELTRANSLATE_MODE</item>
                                       <item translatable="yes">INVLEVELTRANSLATE_MODE</item>
@@ -7924,6 +7942,7 @@ DETECT ENABLE</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Mode for GPIO3v3[3:0] pins</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">LEVELTRANSLATE_MODE</item>
                                       <item translatable="yes">INVLEVELTRANSLATE_MODE</item>
@@ -8216,6 +8235,7 @@ DETECT ENABLE</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Mode for low voltage GPIO[18:16] pins</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">MONITOR_MODE</item>
                                       <item translatable="yes">BITBANG_MODE</item>
@@ -8235,6 +8255,7 @@ DETECT ENABLE</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Mode for low voltage GPIO[15:12] pins</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">MONITOR_MODE</item>
                                       <item translatable="yes">BITBANG_MODE</item>
@@ -8254,6 +8275,7 @@ DETECT ENABLE</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Mode for low voltage GPIO[11:8] pins</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">MONITOR_MODE</item>
                                       <item translatable="yes">BITBANG_MODE</item>
@@ -8273,6 +8295,7 @@ DETECT ENABLE</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Mode for low voltage GPIO[7:4] pins</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">MONITOR_MODE</item>
                                       <item translatable="yes">BITBANG_MODE</item>
@@ -8292,6 +8315,7 @@ DETECT ENABLE</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Mode for low voltage GPIO[3:0] pins</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">MONITOR_MODE</item>
                                       <item translatable="yes">BITBANG_MODE</item>
@@ -9079,6 +9103,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">DAC SLOPE 1.404mV</item>
                           <item translatable="yes">DAC SLOPE 0.705mV</item>
@@ -9096,6 +9121,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">DAC SLOPE 1.404mV</item>
                           <item translatable="yes">DAC SLOPE 0.705mV</item>
@@ -9113,6 +9139,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">DAC SLOPE 1.404mV</item>
                           <item translatable="yes">DAC SLOPE 0.705mV</item>
@@ -9130,6 +9157,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">DAC SLOPE 1.404mV</item>
                           <item translatable="yes">DAC SLOPE 0.705mV</item>
@@ -9147,6 +9175,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">DAC SLOPE 1.404mV</item>
                           <item translatable="yes">DAC SLOPE 0.705mV</item>
@@ -9164,6 +9193,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">DAC SLOPE 1.404mV</item>
                           <item translatable="yes">DAC SLOPE 0.705mV</item>
@@ -9181,6 +9211,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">DAC SLOPE 1.404mV</item>
                           <item translatable="yes">DAC SLOPE 0.705mV</item>
@@ -9198,6 +9229,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">DAC SLOPE 1.404mV</item>
                           <item translatable="yes">DAC SLOPE 0.705mV</item>
@@ -9215,6 +9247,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">DAC SLOPE 1.404mV</item>
                           <item translatable="yes">DAC SLOPE 0.705mV</item>
@@ -9232,6 +9265,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">DAC SLOPE 1.404mV</item>
                           <item translatable="yes">DAC SLOPE 0.705mV</item>
@@ -9249,6 +9283,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VREF 1 V</item>
                           <item translatable="yes">VREF 1.5 V</item>
@@ -9268,6 +9303,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VREF 1 V</item>
                           <item translatable="yes">VREF 1.5 V</item>
@@ -9287,6 +9323,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VREF 1 V</item>
                           <item translatable="yes">VREF 1.5 V</item>
@@ -9306,6 +9343,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VREF 1 V</item>
                           <item translatable="yes">VREF 1.5 V</item>
@@ -9325,6 +9363,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VREF 1 V</item>
                           <item translatable="yes">VREF 1.5 V</item>
@@ -9344,6 +9383,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VREF 1 V</item>
                           <item translatable="yes">VREF 1.5 V</item>
@@ -9363,6 +9403,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VREF 1 V</item>
                           <item translatable="yes">VREF 1.5 V</item>
@@ -9382,6 +9423,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VREF 1 V</item>
                           <item translatable="yes">VREF 1.5 V</item>
@@ -9401,6 +9443,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VREF 1 V</item>
                           <item translatable="yes">VREF 1.5 V</item>
@@ -9420,6 +9463,7 @@ DETECT ENABLE</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">VREF 1 V</item>
                           <item translatable="yes">VREF 1.5 V</item>
@@ -12077,6 +12121,7 @@ DETECT ENABLE</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="active">0</property>
+                                            <property name="entry_text_column">0</property>
                                             <items>
                                               <item translatable="yes">OFF</item>
                                               <item translatable="yes">PRBS 7</item>
@@ -12117,6 +12162,7 @@ DETECT ENABLE</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="active">0</property>
+                                            <property name="entry_text_column">0</property>
                                             <items>
                                               <item translatable="yes">OFF</item>
                                               <item translatable="yes">PRBS 7</item>

--- a/glade/adrv9009.glade
+++ b/glade/adrv9009.glade
@@ -360,6 +360,7 @@
                                               <object class="GtkComboBoxText" id="ensm_mode_available">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="entry_text_column">0</property>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">1</property>
@@ -866,6 +867,7 @@ Hopping Mode</property>
                                               <object class="GtkComboBoxText" id="gain_control_mode_available_rx1">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="entry_text_column">0</property>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">3</property>
@@ -2355,6 +2357,7 @@ Hopping Mode</property>
                                               <object class="GtkComboBoxText" id="rf_port_select_obs">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="entry_text_column">0</property>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">3</property>
@@ -2803,6 +2806,7 @@ Hopping Mode</property>
                                                           <object class="GtkComboBoxText" id="fpga_tx_frequency_available">
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">False</property>
+                                                            <property name="entry_text_column">0</property>
                                                           </object>
                                                           <packing>
                                                             <property name="left_attach">1</property>
@@ -2918,6 +2922,7 @@ Hopping Mode</property>
                                                             <object class="GtkComboBoxText" id="fpga_rx_frequency_available">
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">False</property>
+                                                              <property name="entry_text_column">0</property>
                                                             </object>
                                                             <packing>
                                                             <property name="left_attach">1</property>

--- a/glade/adrv9009_adv.glade
+++ b/glade/adrv9009_adv.glade
@@ -1959,6 +1959,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">CLKPLL high speed clock divider</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">2</item>
                           <item translatable="yes">2.5</item>
@@ -1994,6 +1995,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Set RF PLL phase synchronization mode. Adds extra time to lock RF PLL when PLL frequency changed. See enum for options</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">NOSYNC</item>
                           <item translatable="yes">INIT TRACK</item>
@@ -2302,6 +2304,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">Options to disable Transmit data when the RFPLL unlocks</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">DISABLED</item>
                                       <item translatable="yes">ZERO_DATA</item>
@@ -2380,6 +2383,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">Tx Attenuation step size</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">0.05</item>
                                       <item translatable="yes">0.1</item>
@@ -2414,6 +2418,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">The desired Tx channels to enable during initialization</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">TXOFF</item>
                                       <item translatable="yes">TX1</item>
@@ -2457,6 +2462,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">Talise JESD204b deframer select (Deframer A or B, or both)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">A</item>
                                       <item translatable="yes">B</item>
@@ -2674,6 +2680,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">Tx Int5 filter interpolation (1,5)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">1</item>
                                       <item translatable="yes">5</item>
@@ -2706,6 +2713,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">Tx Halfband3 (HB3) filter interpolation (1,2)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">1</item>
                                       <item translatable="yes">2</item>
@@ -2725,6 +2733,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Tx Halfband2 (HB2) filter interpolation (1,2)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">1</item>
                                       <item translatable="yes">2</item>
@@ -2757,6 +2766,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Tx Halfband1 (HB1) filter interpolation (1,2)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">1</item>
                                       <item translatable="yes">2</item>
@@ -2789,6 +2799,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">The TX digital FIR filter interpolation (1,2,4)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">1</item>
                                       <item translatable="yes">2</item>
@@ -2822,6 +2833,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">The divider used to generate the DAC clock (1,2)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">1</item>
                                       <item translatable="yes">2</item>
@@ -3556,6 +3568,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">GPIO used to decrement Tx attenuation Tx2 : TAL_GPIO_07 or TAL_GPIO_15</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">7</item>
                                       <item translatable="yes">15</item>
@@ -3575,6 +3588,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">GPIO used to increment Tx attenuation Tx1 : TAL_GPIO_04 or TAL_GPIO_12 Tx2 : TAL_GPIO_06 or TAL_GPIO_14</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">6</item>
                                       <item translatable="yes">14</item>
@@ -3643,6 +3657,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">GPIO used to decrement Tx attenuation Tx2 : TAL_GPIO_07 or TAL_GPIO_15</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">5</item>
                                       <item translatable="yes">13</item>
@@ -3662,6 +3677,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">GPIO used to increment Tx attenuation Tx1 : TAL_GPIO_04 or TAL_GPIO_12 Tx2 : TAL_GPIO_06 or TAL_GPIO_14</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">4</item>
                                       <item translatable="yes">12</item>
@@ -3782,6 +3798,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">The desired Rx Channels to enable during initialization</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">RXOFF</item>
                                       <item translatable="yes">RX1</item>
@@ -3812,6 +3829,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">Rx JESD204b framer configuration enum</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">A</item>
                                       <item translatable="yes">B</item>
@@ -3956,6 +3974,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Rx DDC mode</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">BYPASS</item>
                                       <item translatable="yes">FILTERONLY</item>
@@ -4081,6 +4100,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">RX Halfband1 (HB1) decimation. Can be either 1 or 2</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">1</item>
                                       <item translatable="yes">2</item>
@@ -4113,6 +4133,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Decimation of Dec5 or Dec4 filter (5,4)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">4</item>
                                       <item translatable="yes">5</item>
@@ -4145,6 +4166,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">Rx FIR decimation (1,2,4)</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">1</item>
                                       <item translatable="yes">2</item>
@@ -5139,6 +5161,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">GPIO used for the Decrement gain input: Rx1 : TAL_GPIO_01 or TAL_GPIO_11, Rx2 : TAL_GPIO_04 or TAL_GPIO_14</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">4</item>
                                       <item translatable="yes">13</item>
@@ -5171,6 +5194,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">GPIO used for the Increment gain input: Rx1 : TAL_GPIO_00 or TAL_GPIO_10, Rx2 : TAL_GPIO_03 or TAL_GPIO_13</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">3</item>
                                       <item translatable="yes">13</item>
@@ -5282,6 +5306,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">GPIO used for the Decrement gain input: Rx1 : TAL_GPIO_01 or TAL_GPIO_11, Rx2 : TAL_GPIO_04 or TAL_GPIO_14</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">1</item>
                                       <item translatable="yes">11</item>
@@ -5301,6 +5326,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="tooltip_text" translatable="yes">GPIO used for the Increment gain input: Rx1 : TAL_GPIO_00 or TAL_GPIO_10, Rx2 : TAL_GPIO_03 or TAL_GPIO_13</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">0</item>
                                       <item translatable="yes">10</item>
@@ -5490,6 +5516,7 @@
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="tooltip_text" translatable="yes">The desired ObsRx Channel to enable during initialization</property>
+                                        <property name="entry_text_column">0</property>
                                         <items>
                                           <item translatable="yes">OFF</item>
                                           <item translatable="yes">ORX1</item>
@@ -5524,6 +5551,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">Field not used, reserved for future use. The ORx mixers can use the RF_PLL or Aux_PLL</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">RFPLL</item>
                                       <item translatable="yes">AUXPLL</item>
@@ -5567,6 +5595,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">ObsRx JESD204b framer configuration structure</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">A</item>
                                       <item translatable="yes">B</item>
@@ -5642,6 +5671,7 @@
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="tooltip_text" translatable="yes">ORx DDC mode</property>
+                                                <property name="entry_text_column">0</property>
                                                 <items>
                                                   <item translatable="yes">0</item>
                                                 </items>
@@ -5760,6 +5790,7 @@
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="tooltip_text" translatable="yes">ORX Halfband1 (HB1) decimation. Can be either 1 or 2</property>
+                                                <property name="entry_text_column">0</property>
                                                 <items>
                                                   <item translatable="yes">1</item>
                                                   <item translatable="yes">2</item>
@@ -5792,6 +5823,7 @@
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="tooltip_text" translatable="yes">Decimation of Dec5 or Dec4 filter (5,4)</property>
+                                                <property name="entry_text_column">0</property>
                                                 <items>
                                                   <item translatable="yes">4</item>
                                                   <item translatable="yes">5</item>
@@ -5824,6 +5856,7 @@
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="tooltip_text" translatable="yes">ORx FIR decimation (1,2,4)</property>
+                                                <property name="entry_text_column">0</property>
                                                 <items>
                                                   <item translatable="yes">1</item>
                                                   <item translatable="yes">2</item>
@@ -9714,6 +9747,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">Current Rx gain control mode setting</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">MGC</item>
                                       <item translatable="yes">AGC_FAST</item>
@@ -9957,6 +9991,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="tooltip_text" translatable="yes">Current Rx gain control mode setting</property>
+                                    <property name="entry_text_column">0</property>
                                     <items>
                                       <item translatable="yes">MGC</item>
                                       <item translatable="yes">AGC_FAST</item>
@@ -16848,6 +16883,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope (resolution of voltage change per AuxDAC code) - only applies to 10bit DACs (0-9)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">10 Bit</item>
                           <item translatable="yes">11 Bit</item>
@@ -16868,6 +16904,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value for each of the 10-bit DACs</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1V</item>
                           <item translatable="yes">1V5</item>
@@ -16905,6 +16942,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope (resolution of voltage change per AuxDAC code) - only applies to 10bit DACs (0-9)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">10 Bit</item>
                           <item translatable="yes">11 Bit</item>
@@ -16925,6 +16963,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value for each of the 10-bit DACs</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1V</item>
                           <item translatable="yes">1V5</item>
@@ -16962,6 +17001,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope (resolution of voltage change per AuxDAC code) - only applies to 10bit DACs (0-9)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">10 Bit</item>
                           <item translatable="yes">11 Bit</item>
@@ -16982,6 +17022,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value for each of the 10-bit DACs</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1V</item>
                           <item translatable="yes">1V5</item>
@@ -17019,6 +17060,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope (resolution of voltage change per AuxDAC code) - only applies to 10bit DACs (0-9)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">10 Bit</item>
                           <item translatable="yes">11 Bit</item>
@@ -17039,6 +17081,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value for each of the 10-bit DACs</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1V</item>
                           <item translatable="yes">1V5</item>
@@ -17076,6 +17119,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope (resolution of voltage change per AuxDAC code) - only applies to 10bit DACs (0-9)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">10 Bit</item>
                           <item translatable="yes">11 Bit</item>
@@ -17096,6 +17140,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value for each of the 10-bit DACs</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1V</item>
                           <item translatable="yes">1V5</item>
@@ -17133,6 +17178,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope (resolution of voltage change per AuxDAC code) - only applies to 10bit DACs (0-9)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">10 Bit</item>
                           <item translatable="yes">11 Bit</item>
@@ -17153,6 +17199,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value for each of the 10-bit DACs</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1V</item>
                           <item translatable="yes">1V5</item>
@@ -17190,6 +17237,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope (resolution of voltage change per AuxDAC code) - only applies to 10bit DACs (0-9)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">10 Bit</item>
                           <item translatable="yes">11 Bit</item>
@@ -17210,6 +17258,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value for each of the 10-bit DACs</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1V</item>
                           <item translatable="yes">1V5</item>
@@ -17247,6 +17296,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope (resolution of voltage change per AuxDAC code) - only applies to 10bit DACs (0-9)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">10 Bit</item>
                           <item translatable="yes">11 Bit</item>
@@ -17267,6 +17317,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value for each of the 10-bit DACs</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1V</item>
                           <item translatable="yes">1V5</item>
@@ -17304,6 +17355,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope (resolution of voltage change per AuxDAC code) - only applies to 10bit DACs (0-9)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">10 Bit</item>
                           <item translatable="yes">11 Bit</item>
@@ -17324,6 +17376,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value for each of the 10-bit DACs</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1V</item>
                           <item translatable="yes">1V5</item>
@@ -17361,6 +17414,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC slope (resolution of voltage change per AuxDAC code) - only applies to 10bit DACs (0-9)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">10 Bit</item>
                           <item translatable="yes">11 Bit</item>
@@ -17381,6 +17435,7 @@ CALIBRATIONS</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Aux DAC voltage reference value for each of the 10-bit DACs</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1V</item>
                           <item translatable="yes">1V5</item>
@@ -18522,6 +18577,7 @@ INVERT POLARITY</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">converter sample resolution (12, 16, 24)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">12</item>
                           <item translatable="yes">16</item>
@@ -18555,6 +18611,7 @@ INVERT POLARITY</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Number of bytes(octets) per frame (Valid 1, 2, 4, 8)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1</item>
                           <item translatable="yes">2</item>
@@ -18620,6 +18677,7 @@ INVERT POLARITY</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Number of ADCs (0, 2, or 4) where 2 ADCs are required per receive chain (I and Q)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">0</item>
                           <item translatable="yes">2</item>
@@ -18924,6 +18982,7 @@ INVERT POLARITY</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">converter sample resolution (12, 16, 24)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">12</item>
                           <item translatable="yes">16</item>
@@ -18944,6 +19003,7 @@ INVERT POLARITY</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Number of bytes(octets) per frame (Valid 1, 2, 4, 8)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">1</item>
                           <item translatable="yes">2</item>
@@ -18983,6 +19043,7 @@ INVERT POLARITY</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Number of ADCs (0, 2, or 4) where 2 ADCs are required per receive chain (I and Q)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">0</item>
                           <item translatable="yes">2</item>
@@ -19467,6 +19528,7 @@ INVERT POLARITY</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">converter sample resolution (12, 16)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">12</item>
                           <item translatable="yes">16</item>
@@ -19662,6 +19724,7 @@ INVERT POLARITY</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">Number of DACs (0, 2, or 4) - 2 DACs per transmit chain (I and Q)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">0</item>
                           <item translatable="yes">2</item>
@@ -19874,6 +19937,7 @@ INVERT POLARITY</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="tooltip_text" translatable="yes">converter sample resolution (12, 16)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">12</item>
                           <item translatable="yes">16</item>
@@ -20019,6 +20083,7 @@ INVERT POLARITY</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Number of DACs (0, 2, or 4) - 2 DACs per transmit chain (I and Q)</property>
+                        <property name="entry_text_column">0</property>
                         <items>
                           <item translatable="yes">0</item>
                           <item translatable="yes">2</item>
@@ -20329,6 +20394,7 @@ INVERT POLARITY</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="active">0</property>
+                                            <property name="entry_text_column">0</property>
                                             <items>
                                               <item translatable="yes">ADC_DATA</item>
                                               <item translatable="yes">CHECKERBOARD</item>
@@ -20376,6 +20442,7 @@ INVERT POLARITY</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="active">0</property>
+                                            <property name="entry_text_column">0</property>
                                             <items>
                                               <item translatable="yes">ADC_DATA</item>
                                               <item translatable="yes">CHECKERBOARD</item>

--- a/glade/fmcomms11.glade
+++ b/glade/fmcomms11.glade
@@ -134,6 +134,7 @@
                                           <object class="GtkComboBoxText" id="ch0_scales">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="entry_text_column">0</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -200,6 +201,7 @@
                                           <object class="GtkComboBoxText" id="ch0_test_mode">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="entry_text_column">0</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>

--- a/glade/fmcomms2.glade
+++ b/glade/fmcomms2.glade
@@ -638,6 +638,7 @@ configuration:</property>
                                               <object class="GtkComboBoxText" id="dcxo_cal_type">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="entry_text_column">0</property>
                                                 <items>
                                                   <item translatable="yes">REFCLK</item>
                                                   <item translatable="yes">RF Output</item>
@@ -2217,6 +2218,7 @@ configuration:</property>
                                                             <object class="GtkComboBoxText" id="fpga_tx_frequency_available">
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">False</property>
+                                                              <property name="entry_text_column">0</property>
                                                             </object>
                                                             <packing>
                                                             <property name="left_attach">1</property>
@@ -2347,6 +2349,7 @@ configuration:</property>
                                                             <object class="GtkComboBoxText" id="fpga_rx_frequency_available">
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">False</property>
+                                                              <property name="entry_text_column">0</property>
                                                             </object>
                                                             <packing>
                                                             <property name="left_attach">1</property>

--- a/glade/lidar.glade
+++ b/glade/lidar.glade
@@ -471,6 +471,7 @@
                               <object class="GtkComboBoxText" id="cmb_mode">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="entry_text_column">0</property>
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>

--- a/glade/osc.glade
+++ b/glade/osc.glade
@@ -767,6 +767,7 @@ A GUI for Linux IIO devices</property>
                                           <object class="GtkComboBoxText" id="connect_usb_devices">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="entry_text_column">0</property>
                                             <items>
                                               <item translatable="yes">None</item>
                                             </items>
@@ -833,6 +834,7 @@ A GUI for Linux IIO devices</property>
                                           <object class="GtkComboBoxText" id="connect_serial_devices">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="entry_text_column">0</property>
                                             <items>
                                               <item translatable="yes">None</item>
                                             </items>
@@ -848,6 +850,7 @@ A GUI for Linux IIO devices</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="active">6</property>
+                                            <property name="entry_text_column">0</property>
                                             <items>
                                               <item translatable="yes">2400</item>
                                               <item translatable="yes">4800</item>

--- a/glade/spectrum_analyzer.glade
+++ b/glade/spectrum_analyzer.glade
@@ -127,6 +127,7 @@
                   <object class="GtkComboBoxText" id="cmb_available_rbw">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="entry_text_column">0</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>


### PR DESCRIPTION
Recently, we've stopped using some deprecated methods of GtkComboBox and started using the recommended methods that belong to class GtkComboBoxText.
However, GtkComboBoxText objects that are loaded from glade files do not function properly.

GtkComboBoxText has a bug that makes it unsuable (can't get the active text, or insert new text, etc.). In order to work, instances of GtkComboBoxText need the property "entry-text-column" >= 0, which doesn't happen when a GtkComboBoxText is obtained from a glade file (creating them with new works).

To fix this, there's now a script which can parse glade files and add the missing property.

An additional script has been added which should be used to fix glade files edited with Glade versions that target GTK3 and not GTK2.