### PR TITLE
Misc fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,8 @@ set(LIBOSC_LIBS
 	${LIBAD9361_LIBRARIES}
 )
 
+configure_file(config.h.cmakein ${CMAKE_CURRENT_SOURCE_DIR}/config.h @ONLY)
+
 add_library(osc ${OSC_SRC})
 target_link_libraries(osc ${LIBOSC_LIBS})
 set_target_properties(osc PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,25 @@ file(GLOB GLADE_FILES glade/*.glade)
 file(GLOB ICON_FILES icons/*)
 
 install(FILES ${GLADE_FILES} ${ICON_FILES} DESTINATION ${SHARE_DEST})
+# install theme icons
+install(FILES icons/osc16.png RENAME adi-osc.png
+	DESTINATION /usr/share/icons/hicolor/16x16/apps)
+install(FILES icons/osc32.png RENAME adi-osc.png
+	DESTINATION /usr/share/icons/hicolor/32x32/apps/adi-osc.png)
+install(FILES icons/osc64.png RENAME adi-osc.png
+	DESTINATION /usr/share/icons/hicolor/64x64/apps/adi-osc.png)
+install(FILES icons/osc128.png RENAME adi-osc.png
+	DESTINATION /usr/share/icons/hicolor/128x128/apps/adi-osc.png)
+install(FILES icons/osc256.png RENAME adi-osc.png
+	DESTINATION /usr/share/icons/hicolor/256x256/apps/adi-osc.png)
+install(FILES icons/osc.svg RENAME adi-osc.svg
+	DESTINATION /usr/share/icons/hicolor/scalable/apps)
+
+# This is a bit "ugly". It makes sure that the hicolor theme directory updates
+# it's modification date. This makes sure that osc icons are loaded right away.
+# We can also just remove this and assume the user has do this manually or run
+# something like `gtk-update-icon-cache -f /usr/share/icons/hicolor`.
+install(CODE "EXECUTE_PROCESS(COMMAND sh -c \"touch /usr/share/icons/hicolor\")")
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	configure_file(adi-osc.desktop.cmakein ${CMAKE_CURRENT_BINARY_DIR}/adi-osc.desktop @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,11 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	configure_file(org.adi.pkexec.osc.policy.cmakein ${CMAKE_CURRENT_BINARY_DIR}/org.adi.pkexec.osc.policy @ONLY)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.adi.pkexec.osc.policy
 		DESTINATION /usr/share/polkit-1/actions/)
+	# setup exec script
+	configure_file(osc-wrapper.cmakein ${CMAKE_CURRENT_SOURCE_DIR}/osc-wrapper @ONLY)
+	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/osc-wrapper
+		PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+		DESTINATION bin)
 endif()
 
 set(PLIB_DEST lib/osc)

--- a/adi-osc.desktop.cmakein
+++ b/adi-osc.desktop.cmakein
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Exec=pkexec @CMAKE_INSTALL_PREFIX@/bin/osc
+Exec=@CMAKE_INSTALL_PREFIX@/bin/osc-wrapper
 Icon=@CMAKE_INSTALL_PREFIX@/@SHARE_DEST@/icons/osc.svg
 Terminal=false
 Type=Application

--- a/config.h.cmakein
+++ b/config.h.cmakein
@@ -9,7 +9,7 @@
 #define __CONFIG_H__
 
 #ifndef PREFIX
-#	define PREFIX "/usr/local/"
+#	define PREFIX "@CMAKE_INSTALL_PREFIX@"
 #endif
 
 #define OSC_GLADE_FILE_PATH PREFIX "/share/osc/"

--- a/glade/osc.glade
+++ b/glade/osc.glade
@@ -541,6 +541,7 @@ A GUI for Linux IIO devices</property>
     <property name="border_width">5</property>
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">adi-osc</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox6">
         <property name="can_focus">False</property>

--- a/glade/oscplot.glade
+++ b/glade/oscplot.glade
@@ -58,6 +58,7 @@
   <object class="GtkDialog" id="channel_trigger_dialog">
     <property name="can_focus">False</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">adi-osc</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="box4">
         <property name="visible">True</property>
@@ -259,6 +260,7 @@
     <property name="title" translatable="yes">Math Settings</property>
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">adi-osc</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="can_focus">False</property>
@@ -425,6 +427,7 @@
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Plot Title Edit</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">adi-osc</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox6">
         <property name="can_focus">False</property>
@@ -532,6 +535,7 @@
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Channel Math Expression Chooser</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">adi-osc</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox5">
         <property name="can_focus">False</property>
@@ -1635,6 +1639,7 @@
     <property name="type_hint">dialog</property>
     <property name="action">save</property>
     <property name="do_overwrite_confirmation">True</property>
+    <property name="icon_name">adi-osc</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="filechooserdialog-vbox3">
         <property name="can_focus">False</property>
@@ -2928,6 +2933,7 @@
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="type_hint">dialog</property>
+    <property name="icon_name">adi-osc</property>
 	<property name="title" translatable="yes">Select Impulse Generator</property>
 	<property name="resizable">False</property>
     <child internal-child="vbox">

--- a/osc-wrapper.cmakein
+++ b/osc-wrapper.cmakein
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Some application launchers will execute osc and just reap it so that
+# osc parent becomes PID 1 which is not allowed by pkexec. Hence the need
+# of a wrapper script.
+pkexec @CMAKE_INSTALL_PREFIX@/bin/osc "$@"
+


### PR DESCRIPTION
This series is mainly fixing the icons rendering for osc. The icons were just not being rendered in the app window (in window managers that render the icon on the windows). I'm not sure if this is the "best" way of doing this since I'm not really familiar on how apps usually ship this kind of UI elements. However, this PR has, at least, the goal of bringing the attention to this.
Moreover, there is a patch to not hardcode the `PREFIX` path to /usr/local and to fix the .desktop entry on some application launcher...

This series was tested in ubuntu18.04 and arch linux.