### PR TITLE
ci,os-x: reduce build times by not upgrading

### DIFF
--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -8,10 +8,6 @@ brew_install_if_not_exists cmake fftw libmatio \
 	jansson glib curl openssl@1.1 flex bison \
 	gettext libserialport
 
-for pkg in gcc bison gettext ; do
-	brew link --overwrite --force $pkg
-done
-
 if [ "$TRAVIS" == "true" ] ; then
 	for pkg in libiio libad9361-iio ; do
 		wget http://swdownloads.analog.com/cse/travis_builds/master_latest_${pkg}${LDIST}.pkg

--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -3,7 +3,7 @@
 . CI/travis/lib.sh
 . CI/travis/before_install_lib.sh
 
-brew_install_or_upgrade cmake fftw libmatio \
+brew_install_if_not_exists cmake fftw libmatio \
 	libxml2 pkg-config libusb gtk+ gtkdatabox \
 	jansson glib curl openssl@1.1 flex bison \
 	gettext libserialport


### PR DESCRIPTION
Travis-CI OS X images have plenty of stuff installed. And they are updated
every now-n-then. Running `brew upgrade` can take too much on older images.

So, don't upgrade packages. Just use the ones installed.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>