### PR TITLE
build: Fix Makefile based build

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2012-2013(c) Analog Devices, Inc.
+ *
+ * Licensed under the GPL-2.
+ *
+ **/
+
+#ifndef __CONFIG_H__
+#define __CONFIG_H__
+
+#ifndef PREFIX
+#	define PREFIX "/usr/local"
+#endif
+
+#define OSC_GLADE_FILE_PATH PREFIX "/share/osc/"
+#define OSC_PLUGIN_PATH PREFIX "/lib/osc/"
+#define OSC_XML_PATH PREFIX "/lib/osc/xmls"
+#define OSC_FILTER_FILE_PATH PREFIX "/lib/osc/filters"
+#define OSC_WAVEFORM_FILE_PATH PREFIX "/lib/osc/waveforms"
+#define OSC_PROFILES_FILE_PATH PREFIX "/lib/osc/profiles"
+
+#endif


### PR DESCRIPTION
The change introduced by 8afb45d ("build: config.h: Don't hardcode PREFIX
path") breaks the Makefile based build since there's no `config` header.
This can break some older builds that still rely on the Makefile build.
This patch restores the original file so that it works the same way it
used to work with make. When using cmake, this file will be overwritten
maintaining the behavior introduced by the mentioned patch.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>