### PR TITLE
build,ci: remove tracing; reduce log output

### DIFF
--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 . CI/travis/before_install_lib.sh

--- a/CI/travis/before_install_lib.sh
+++ b/CI/travis/before_install_lib.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . ./CI/travis/lib.sh
 

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 . CI/travis/before_install_lib.sh

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR:-'./'}
 

--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
 

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 


### PR DESCRIPTION
Tracing can be useful in debugging situations.
Remove it for normal builds, as it can be too much.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>