### PR TITLE
ci,os-x: reduce build times

### DIFF
--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -5,10 +5,10 @@
 
 brew_install_if_not_exists cmake fftw libmatio \
 	libxml2 pkg-config libusb gtk+ gtkdatabox \
-	jansson glib curl openssl@1.1 flex bison \
+	jansson glib curl openssl@1.1 \
 	gettext libserialport
 
-for pkg in bison gettext ; do
+for pkg in gettext ; do
 	brew link --overwrite --force $pkg
 done
 

--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -8,7 +8,7 @@ brew_install_if_not_exists cmake fftw libmatio \
 	jansson glib curl openssl@1.1 flex bison \
 	gettext libserialport
 
-for pkg in gcc bison gettext ; do
+for pkg in bison gettext ; do
 	brew link --overwrite --force $pkg
 done
 

--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -3,7 +3,7 @@
 . CI/travis/lib.sh
 . CI/travis/before_install_lib.sh
 
-brew_install_or_upgrade cmake fftw libmatio \
+brew_install_if_not_exists cmake fftw libmatio \
 	libxml2 pkg-config libusb gtk+ gtkdatabox \
 	jansson glib curl openssl@1.1 flex bison \
 	gettext libserialport


### PR DESCRIPTION
This changeset tries to reduce the build time for OS X builds.
On average, it used to be 8 minutes on Xcode 10. With this changeset it's about 5, because some packages are not installed, because they are already present in the image provided by Travis-CI.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>