### PR TITLE
Fix buffer size reading attr

### DIFF
--- a/iio_utils.h
+++ b/iio_utils.h
@@ -10,6 +10,8 @@
 #include "iio.h"
 #include <gmodule.h>
 
+#define IIO_ATTR_MAX_BYTES 16384
+
 GArray * get_iio_devices_starting_with(struct iio_context *ctx, const char *sequence);
 
 GArray * get_iio_channels_naturally_sorted(struct iio_device *dev);

--- a/plugins/debug.c
+++ b/plugins/debug.c
@@ -244,7 +244,7 @@ static void debug_scanel_changed_cb(GtkComboBoxText *cmbText, gpointer data)
 {
 	char *options_attr_val;
 	const char *options_attr;
-	const char *attr;
+	char *attr;
 	char buf[256];
 
 	attr = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(cmbText));
@@ -261,7 +261,7 @@ static void debug_scanel_changed_cb(GtkComboBoxText *cmbText, gpointer data)
 
 		options_attr_val = g_new(char, IIO_ATTR_MAX_BYTES);
 		if (!options_attr_val)
-			return;
+			goto cleanup;
 
 		attribute_has_options = true;
 		if (current_ch)
@@ -303,6 +303,9 @@ static void debug_scanel_changed_cb(GtkComboBoxText *cmbText, gpointer data)
 		gtk_entry_set_text(GTK_ENTRY(scanel_filename), attr);
 
 	scanel_read_clicked(GTK_BUTTON(scanel_read), NULL);
+
+cleanup:
+	g_free(attr);
 }
 
 static void attribute_type_changed_cb(GtkComboBoxText *cmbtext, gpointer data)


### PR DESCRIPTION
Provide larger buffers to store the content of iio attributes since 1024 isn't enough. Some attributes can be larger than that.