### PR TITLE
ci,osx: do brew unlink python@2 before installing packets

### DIFF
--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -3,6 +3,8 @@
 . CI/travis/lib.sh
 . CI/travis/before_install_lib.sh
 
+brew unlink python@2
+
 brew_install_if_not_exists cmake fftw libmatio \
 	libxml2 pkg-config libusb gtk+ gtkdatabox \
 	jansson glib curl openssl@1.1 \


### PR DESCRIPTION
Homebrew has updated it's default `python` package to point at `python@3`.
Unfortunately, there is no clean way to fix this for osc. Or, I could not
find one.

When installing libmatio, it seems to pull `python@3`, and this seems to
conflict with python@2.
So, unlink it.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>