### PR TITLE
plugins/generic_plugin: Initial version for a generic plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ OSC := osc$(EXE)
 LIBOSC := libosc.$(SO)
 
 PLUGINS=\
+	plugins/generic_plugin.$(SO) \
 	plugins/fmcomms1.$(SO) \
 	plugins/fmcomms2.$(SO) \
 	plugins/fmcomms5.$(SO) \

--- a/glade/generic_plugin.glade
+++ b/glade/generic_plugin.glade
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="2.24"/>
+  <!-- interface-naming-policy project-wide -->
+  <object class="GtkVBox" id="generic_panel">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkNotebook" id="plugin_notebook">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <child>
+          <object class="GtkAlignment" id="alignment1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkVBox" id="dds_vbox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="tab">
+          <object class="GtkLabel" id="label1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="yalign">0.51999998092651367</property>
+            <property name="label" translatable="yes">Controls</property>
+          </object>
+          <packing>
+            <property name="tab_fill">False</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child type="tab">
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child type="tab">
+          <placeholder/>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/osc.c
+++ b/osc.c
@@ -928,6 +928,29 @@ static void load_plugin_finish(GtkNotebook *notebook,
 	plugin_make_detachable(d_plugin);
 }
 
+static void generic_plugin_handle(struct osc_plugin *generic_plugin, void *generic_lib, const char *ini_fn) {
+	struct params {
+		struct osc_plugin *plugin;
+		GtkWidget *notebook;
+		const char *ini_fn;
+	} *params;
+
+	if (!generic_plugin || !generic_lib)
+		return;
+
+	plugin_list = g_slist_append (plugin_list, (gpointer) generic_plugin);
+	plugin_lib_list = g_slist_append(plugin_lib_list, generic_lib);
+
+	params = malloc(sizeof(*params));
+	params->plugin = generic_plugin;
+	params->notebook = notebook;
+	params->ini_fn = ini_fn;
+
+	GtkWidget *widget = init_plugin(params);
+	if (widget)
+		load_plugin_finish(GTK_NOTEBOOK(notebook), widget, generic_plugin);
+}
+
 static void load_plugins(GtkWidget *notebook, const char *ini_fn)
 {
 	typedef GArray* (*get_plugins_info_func)(void);
@@ -939,6 +962,8 @@ static void load_plugins(GtkWidget *notebook, const char *ini_fn)
 	char *plugin_dir = "plugins";
 	char buf[512];
 	DIR *d;
+	struct osc_plugin *generic_plugin = NULL;
+	void *generic_lib = NULL;
 
 #ifdef __MINGW32__
 	const bool load_in_parallel = false;
@@ -1020,6 +1045,11 @@ static void load_plugins(GtkWidget *notebook, const char *ini_fn)
 			}
 
 			plugin->handle = lib;
+			if (!strcmp(plugin->name, "GENERIC_PLUGIN")) {
+				generic_plugin = plugin;
+				generic_lib = lib;
+				continue;
+			}
 			plugin_list = g_slist_append (plugin_list, (gpointer) plugin);
 			plugin_lib_list = g_slist_append(plugin_lib_list, lib);
 		}
@@ -1050,8 +1080,10 @@ static void load_plugins(GtkWidget *notebook, const char *ini_fn)
 		}
 	}
 
-	if (!load_in_parallel)
+	if (!load_in_parallel) {
+		generic_plugin_handle(generic_plugin, generic_lib, ini_fn);
 		return;
+	}
 
 	/* Wait for all init functions to finish */
 	for (node = plugin_list; node; node = g_slist_next(node)) {
@@ -1068,6 +1100,7 @@ static void load_plugins(GtkWidget *notebook, const char *ini_fn)
 		load_plugin_finish(GTK_NOTEBOOK(notebook), widget, plugin);
 		printf("Loaded plugin: %s\n", plugin->name);
 	}
+	generic_plugin_handle(generic_plugin, generic_lib, ini_fn);
 }
 
 static void plugin_state_ini_save(gpointer data, gpointer user_data)

--- a/osc_plugin.h
+++ b/osc_plugin.h
@@ -36,7 +36,7 @@ struct osc_plugin {
 
 	void (*save_profile)(const struct osc_plugin *plugin, const char *ini_fn);
 	void (*load_profile)(struct osc_plugin *plugin, const char *ini_fn);
-
+	GSList* (*get_dac_dev_names)(void);
 	struct plugin_private *priv;
 };
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -16,6 +16,7 @@
 #  Boston, MA 02110-1301, USA.
 
 set(PLUGINS
+	generic_plugin
 	fmcomms1
 	fmcomms2
 	fmcomms2_adv

--- a/plugins/ad9371.c
+++ b/plugins/ad9371.c
@@ -1922,6 +1922,14 @@ static bool ad9371_identify(const struct osc_plugin *plugin)
 	return !iio_context_find_device(osc_ctx, "ad9371-phy-B");
 }
 
+GSList* get_dac_dev_names(void) {
+	GSList *list = NULL;
+
+	list = g_slist_append (list, (gpointer) DDS_DEVICE);
+
+	return list;
+}
+
 struct osc_plugin plugin = {
 	.name = THIS_DRIVER,
 	.identify = ad9371_identify,
@@ -1933,4 +1941,5 @@ struct osc_plugin plugin = {
 	.save_profile = save_profile,
 	.load_profile = load_profile,
 	.destroy = context_destroy,
+	.get_dac_dev_names = get_dac_dev_names,
 };

--- a/plugins/ad9739a.c
+++ b/plugins/ad9739a.c
@@ -272,6 +272,14 @@ static bool ad9739a_identify(const struct osc_plugin *plugin)
 	return !!iio_context_find_device(osc_ctx, DAC_DEVICE);
 }
 
+GSList* get_dac_dev_names(void) {
+	GSList *list = NULL;
+
+	list = g_slist_append (list, (gpointer) DAC_DEVICE);
+
+	return list;
+}
+
 struct osc_plugin plugin = {
 	.name = THIS_DRIVER,
 	.identify = ad9739a_identify,
@@ -280,4 +288,5 @@ struct osc_plugin plugin = {
 	.save_profile = save_profile,
 	.load_profile = load_profile,
 	.destroy = context_destroy,
+	.get_dac_dev_names = get_dac_dev_names,
 };

--- a/plugins/adrv9009.c
+++ b/plugins/adrv9009.c
@@ -1784,6 +1784,14 @@ static bool adrv9009_identify(const struct osc_plugin *plugin)
 	return !!iio_context_find_device(osc_ctx, PHY_DEVICE);
 }
 
+GSList* get_dac_dev_names(void) {
+	GSList *list = NULL;
+
+	list = g_slist_append (list, (gpointer) DDS_DEVICE);
+
+	return list;
+}
+
 struct osc_plugin plugin = {
 	.name = THIS_DRIVER,
 	.identify = adrv9009_identify,
@@ -1795,4 +1803,5 @@ struct osc_plugin plugin = {
 	.save_profile = save_profile,
 	.load_profile = load_profile,
 	.destroy = context_destroy,
+	.get_dac_dev_names = get_dac_dev_names,
 };

--- a/plugins/daq2.c
+++ b/plugins/daq2.c
@@ -414,6 +414,16 @@ static bool daq2_identify(const struct osc_plugin *plugin)
 		!!iio_context_find_device(osc_ctx, ADC_DEVICE);
 }
 
+GSList* get_dac_dev_names(void) {
+	GSList *list = NULL;
+
+	list = g_slist_append (list, (gpointer) DAQ1_DAC_DEVICE);
+	list = g_slist_append (list, (gpointer) DAQ2_DAC_DEVICE);
+	list = g_slist_append (list, (gpointer) DAQ3_DAC_DEVICE);
+
+	return list;
+}
+
 struct osc_plugin plugin = {
 	.name = THIS_DRIVER,
 	.identify = daq2_identify,
@@ -422,4 +432,5 @@ struct osc_plugin plugin = {
 	.save_profile = save_profile,
 	.load_profile = load_profile,
 	.destroy = context_destroy,
+	.get_dac_dev_names = get_dac_dev_names,
 };

--- a/plugins/fmcomms1.c
+++ b/plugins/fmcomms1.c
@@ -2051,6 +2051,14 @@ static bool fmcomms1_identify(const struct osc_plugin *plugin)
 	return !!iio_context_find_device(osc_ctx, "cf-ad9122-core-lpc");
 }
 
+GSList* get_dac_dev_names(void) {
+	GSList *list = NULL;
+
+	list = g_slist_append (list, (gpointer) "cf-ad9122-core-lpc");
+
+	return list;
+}
+
 struct osc_plugin plugin = {
 	.name = THIS_DRIVER,
 	.identify = fmcomms1_identify,
@@ -2059,4 +2067,5 @@ struct osc_plugin plugin = {
 	.save_profile = save_profile,
 	.load_profile = load_profile,
 	.destroy = context_destroy,
+	.get_dac_dev_names = get_dac_dev_names,
 };

--- a/plugins/fmcomms11.c
+++ b/plugins/fmcomms11.c
@@ -393,6 +393,14 @@ static bool fmcomms11_identify(const struct osc_plugin *plugin)
 		!!iio_context_find_device(osc_ctx, ATTN_DEVICE);
 }
 
+GSList* get_dac_dev_names(void) {
+	GSList *list = NULL;
+
+	list = g_slist_append (list, (gpointer) DAC_DEVICE);
+
+	return list;
+}
+
 struct osc_plugin plugin = {
 	.name = THIS_DRIVER,
 	.identify = fmcomms11_identify,
@@ -401,4 +409,5 @@ struct osc_plugin plugin = {
 	.save_profile = save_profile,
 	.load_profile = load_profile,
 	.destroy = context_destroy,
+	.get_dac_dev_names = get_dac_dev_names,
 };

--- a/plugins/fmcomms2.c
+++ b/plugins/fmcomms2.c
@@ -2129,6 +2129,14 @@ static bool fmcomms2_identify(const struct osc_plugin *plugin)
 	return !iio_context_find_device(osc_ctx, "ad9361-phy-B");
 }
 
+GSList* get_dac_dev_names(void) {
+	GSList *list = NULL;
+
+	list = g_slist_append (list, (gpointer) DDS_DEVICE);
+
+	return list;
+}
+
 struct osc_plugin plugin = {
 	.name = THIS_DRIVER,
 	.identify = fmcomms2_identify,
@@ -2140,4 +2148,5 @@ struct osc_plugin plugin = {
 	.save_profile = save_profile,
 	.load_profile = load_profile,
 	.destroy = context_destroy,
+	.get_dac_dev_names = get_dac_dev_names,
 };

--- a/plugins/fmcomms5.c
+++ b/plugins/fmcomms5.c
@@ -1760,6 +1760,15 @@ static bool fmcomms5_identify(const struct osc_plugin *plugin)
 	return !!dev1 && !!dds1 && !!cap1 && !!dev2 && !!dds2 && !!cap2;
 }
 
+GSList* get_dac_dev_names(void) {
+	GSList *list = NULL;
+
+	list = g_slist_append (list, (gpointer) DDS_DEVICE1);
+	list = g_slist_append (list, (gpointer) DDS_DEVICE2);
+
+	return list;
+}
+
 struct osc_plugin plugin = {
 	.name = THIS_DRIVER,
 	.identify = fmcomms5_identify,
@@ -1771,4 +1780,5 @@ struct osc_plugin plugin = {
 	.save_profile = save_profile,
 	.load_profile = load_profile,
 	.destroy = context_destroy,
+	.get_dac_dev_names = get_dac_dev_names,
 };

--- a/plugins/generic_plugin.c
+++ b/plugins/generic_plugin.c
@@ -1,0 +1,204 @@
+/**
+ * Copyright (C) 2019 Analog Devices, Inc.
+ *
+ * Licensed under the GPL-2.
+ *
+ **/
+#include <stdio.h>
+
+#include <gtk/gtk.h>
+#include <glib.h>
+#include <gtkdatabox.h>
+#include <gtkdatabox_grid.h>
+#include <gtkdatabox_points.h>
+#include <gtkdatabox_lines.h>
+#include <math.h>
+#include <stdint.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <string.h>
+
+#include <iio.h>
+
+#include "../libini2.h"
+#include "../osc.h"
+#include "../iio_widget.h"
+#include "../osc_plugin.h"
+#include "../config.h"
+#include "../eeprom.h"
+#include "dac_data_manager.h"
+
+#define THIS_DRIVER "GENERIC_PLUGIN"
+
+#define ARRAY_SIZE(x) (!sizeof(x) ?: sizeof(x) / sizeof((x)[0]))
+
+static struct dac_data_manager *dac_tx_manager;
+static GSList *dac_tx_manager_list = NULL;
+
+static struct iio_context *ctx;
+static struct iio_device *dac;
+
+static struct iio_widget tx_widgets[100];
+static unsigned int num_tx;
+
+static bool can_update_widgets;
+
+static void tx_update_values(void)
+{
+	iio_update_widgets(tx_widgets, num_tx);
+}
+
+static void save_widget_value(GtkWidget *widget, struct iio_widget *iio_w)
+{
+	iio_w->save(iio_w);
+}
+
+static void make_widget_update_signal_based(struct iio_widget *widgets,
+		unsigned int num_widgets)
+{
+	char signal_name[25];
+	unsigned int i;
+
+	for (i = 0; i < num_widgets; i++) {
+		if (GTK_IS_CHECK_BUTTON(widgets[i].widget))
+			sprintf(signal_name, "%s", "toggled");
+		else if (GTK_IS_TOGGLE_BUTTON(widgets[i].widget))
+			sprintf(signal_name, "%s", "toggled");
+		else if (GTK_IS_SPIN_BUTTON(widgets[i].widget))
+			sprintf(signal_name, "%s", "value-changed");
+		else if (GTK_IS_COMBO_BOX_TEXT(widgets[i].widget))
+			sprintf(signal_name, "%s", "changed");
+		else
+			printf("unhandled widget type, attribute: %s\n", widgets[i].attr_name);
+
+		if (GTK_IS_SPIN_BUTTON(widgets[i].widget) &&
+		    widgets[i].priv_progress != NULL) {
+			iio_spin_button_progress_activate(&widgets[i]);
+		} else {
+			g_signal_connect(G_OBJECT(widgets[i].widget), signal_name,
+					 G_CALLBACK(save_widget_value), &widgets[i]);
+		}
+	}
+}
+
+static bool generic_identify(const struct osc_plugin *plugin)
+{
+	return 1;
+}
+
+static GSList * get_dac_dev_names(void)
+{
+	GSList *node;
+	GSList *dac_dev_names = NULL;
+	struct osc_plugin *plugin;
+
+	for (node = plugin_list; node; node = g_slist_next(node)) {
+		plugin = node->data;
+		if (plugin->get_dac_dev_names)
+			dac_dev_names = g_slist_concat (dac_dev_names, plugin->get_dac_dev_names());
+	}
+
+	return dac_dev_names;
+}
+
+static gint compare_func(gconstpointer a, gconstpointer b)
+{
+	const char *pa = a, *pb = b;
+
+	return strcmp(pa, pb);
+}
+
+static GtkWidget * generic_init(struct osc_plugin *plugin, GtkWidget *notebook,
+				const char *ini_fn)
+{
+	GtkBuilder *builder;
+	GtkWidget *generic_panel;
+	GtkWidget *dds_container;
+	GtkWidget *dds_vbox;
+	bool generic_en = false;
+	int i, dev_count;
+	GSList * dac_dev_names;
+	const char *crt_dev_name;
+
+	ctx = osc_create_context();
+	if (!ctx)
+		return NULL;
+
+	builder = gtk_builder_new();
+	if (osc_load_glade_file(builder, "generic_plugin") < 0)
+		return NULL;
+
+	generic_panel = GTK_WIDGET(gtk_builder_get_object(builder, "generic_panel"));
+	dds_vbox = GTK_WIDGET(gtk_builder_get_object(builder, "dds_vbox"));
+	dac_dev_names = get_dac_dev_names();
+	dev_count = iio_context_get_devices_count(ctx);
+
+	for (i = 0; i < dev_count; i++) {
+		dac = iio_context_get_device(ctx, i);
+		dac_tx_manager = dac_data_manager_new(dac, NULL, ctx);
+		if (!dac_tx_manager)
+			continue;
+
+		crt_dev_name = iio_device_get_name(dac);
+		if (g_slist_find_custom(dac_dev_names, crt_dev_name, compare_func))
+			continue;
+
+		generic_en = true;
+
+		dds_container = gtk_frame_new("DDS");
+		gtk_container_add(GTK_CONTAINER(dds_vbox), dds_container);
+		gtk_container_add(GTK_CONTAINER(dds_container),
+				  dac_data_manager_get_gui_container(dac_tx_manager));
+		gtk_widget_show_all(dds_container);
+
+		dac_data_manager_freq_widgets_range_update(dac_tx_manager, INT_MAX / 2.0);
+		dac_data_manager_update_iio_widgets(dac_tx_manager);
+
+		make_widget_update_signal_based(tx_widgets, num_tx);
+
+		tx_update_values();
+		dac_data_manager_update_iio_widgets(dac_tx_manager);
+
+		dac_data_manager_set_buffer_size_alignment(dac_tx_manager, 16);
+		dac_data_manager_set_buffer_chooser_current_folder(dac_tx_manager,
+				OSC_WAVEFORM_FILE_PATH);
+
+		dac_tx_manager_list = g_slist_append(dac_tx_manager_list, (gpointer) dac_tx_manager);
+
+		can_update_widgets = true;
+	}
+
+	g_slist_free(dac_dev_names);
+
+	if (!generic_en) {
+		osc_destroy_context(ctx);
+		return NULL;
+	}
+
+	return generic_panel;
+}
+
+static void context_destroy(struct osc_plugin *plugin, const char *ini_fn)
+{
+	GSList *node;
+
+	for (node = dac_tx_manager_list; node; node = g_slist_next(node)) {
+		dac_tx_manager = node->data;
+		dac_data_manager_free(dac_tx_manager);
+		dac_tx_manager = NULL;
+	}
+	g_slist_free(dac_tx_manager_list);
+	dac_tx_manager_list = NULL;
+
+	osc_destroy_context(ctx);
+}
+
+struct osc_plugin plugin = {
+	.name = THIS_DRIVER,
+	.identify = generic_identify,
+	.init = generic_init,
+	.destroy = context_destroy,
+};


### PR DESCRIPTION
The generic plugin is used when no other plugin has been created and
provides a means of loading a data file and sending it as a buffer to a dac
device. It creates a gui panel for each device with dac properties.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>
Signed-off-by: Cristian Pop <cristian.pop@analog.com>