### PR TITLE
plugins: ad9081: Fix different signedness comparison

### DIFF
--- a/plugins/ad9081.c
+++ b/plugins/ad9081.c
@@ -67,7 +67,7 @@ static void __iio_update_widgets(GtkWidget *widget, struct plugin_private *priv)
 	priv->has_once_updated = true;
 }
 
-static void select_page_cb(GtkNotebook *notebook, gpointer arg1, guint page,
+static void select_page_cb(GtkNotebook *notebook, gpointer arg1, gint page,
 			   struct plugin_private *priv)
 {
 	if (!priv->has_once_updated && page == priv->this_page)


### PR DESCRIPTION
plugins/ad9081.c: In function ‘select_page_cb’:
plugins/ad9081.c:73:38: error: comparison of integer expressions of
different signedness: ‘guint’ {aka ‘unsigned int’} and ‘gint’ {aka
‘int’} [-Werror=sign-compare]
  if (!priv->has_once_updated && page == priv->this_page)
                                                               ^~

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>