### PR TITLE
plugins: ad9081: Implement get_dac_dev_names()

### DIFF
--- a/plugins/ad9081.c
+++ b/plugins/ad9081.c
@@ -34,6 +34,8 @@
 const gdouble mhz_scale = 1000000.0;
 const gdouble k_scale = 1000.0;
 
+const char *dac_name;
+
 struct plugin_private {
 	/* plugin context */
 	struct osc_plugin_context plugin_ctx;
@@ -439,6 +441,7 @@ tx_chann:
 		}
 
 		dac = g_array_index(devices, struct iio_device*, 0);
+		dac_name = iio_device_get_name(dac);
 		priv->dac_tx_manager = dac_data_manager_new(dac, NULL, priv->ctx);
 		if (!priv->dac_tx_manager) {
 			printf("%s: Failed to start dac Manager...\n",
@@ -539,6 +542,14 @@ static void context_destroy(struct osc_plugin *plugin, const char *ini_fn)
 	g_free(priv);
 }
 
+GSList* get_dac_dev_names(void) {
+	GSList *list = NULL;
+
+	if (dac_name)
+		list = g_slist_append (list, (gpointer) dac_name);
+
+	return list;
+}
 
 struct osc_plugin *create_plugin(struct osc_plugin_context *plugin_ctx)
 {
@@ -561,6 +572,7 @@ struct osc_plugin *create_plugin(struct osc_plugin_context *plugin_ctx)
 	plugin->get_preferred_size = ad9081_get_preferred_size;
 	plugin->update_active_page = update_active_page;
 	plugin->destroy = context_destroy;
+	plugin->get_dac_dev_names = get_dac_dev_names;
 
 	return plugin;
 }


### PR DESCRIPTION
For preventing the generic_dac plugin to be loaded (since AD9081 has a
dedicated plugin), get_dac_dev_names() should be implemented.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>