### PR TITLE
plugins: Add osc_plugin parameter to get_dac_dev_names()

### DIFF
--- a/osc_plugin.h
+++ b/osc_plugin.h
@@ -36,7 +36,7 @@ struct osc_plugin {
 
 	void (*save_profile)(const struct osc_plugin *plugin, const char *ini_fn);
 	void (*load_profile)(struct osc_plugin *plugin, const char *ini_fn);
-	GSList* (*get_dac_dev_names)(void);
+	GSList* (*get_dac_dev_names)(const struct osc_plugin *plugin);
 	struct plugin_private *priv;
 };
 

--- a/plugins/ad9371.c
+++ b/plugins/ad9371.c
@@ -1922,7 +1922,7 @@ static bool ad9371_identify(const struct osc_plugin *plugin)
 	return !iio_context_find_device(osc_ctx, "ad9371-phy-B");
 }
 
-GSList* get_dac_dev_names(void) {
+GSList* get_dac_dev_names(const struct osc_plugin *plugin) {
 	GSList *list = NULL;
 
 	list = g_slist_append (list, (gpointer) DDS_DEVICE);

--- a/plugins/ad9739a.c
+++ b/plugins/ad9739a.c
@@ -272,7 +272,7 @@ static bool ad9739a_identify(const struct osc_plugin *plugin)
 	return !!iio_context_find_device(osc_ctx, DAC_DEVICE);
 }
 
-GSList* get_dac_dev_names(void) {
+GSList* get_dac_dev_names(const struct osc_plugin *plugin) {
 	GSList *list = NULL;
 
 	list = g_slist_append (list, (gpointer) DAC_DEVICE);

--- a/plugins/adrv9009.c
+++ b/plugins/adrv9009.c
@@ -1784,7 +1784,7 @@ static bool adrv9009_identify(const struct osc_plugin *plugin)
 	return !!iio_context_find_device(osc_ctx, PHY_DEVICE);
 }
 
-GSList* get_dac_dev_names(void) {
+GSList* get_dac_dev_names(const struct osc_plugin *plugin) {
 	GSList *list = NULL;
 
 	list = g_slist_append (list, (gpointer) DDS_DEVICE);

--- a/plugins/daq2.c
+++ b/plugins/daq2.c
@@ -414,7 +414,7 @@ static bool daq2_identify(const struct osc_plugin *plugin)
 		!!iio_context_find_device(osc_ctx, ADC_DEVICE);
 }
 
-GSList* get_dac_dev_names(void) {
+GSList* get_dac_dev_names(const struct osc_plugin *plugin) {
 	GSList *list = NULL;
 
 	list = g_slist_append (list, (gpointer) DAQ1_DAC_DEVICE);

--- a/plugins/fmcomms1.c
+++ b/plugins/fmcomms1.c
@@ -2051,7 +2051,7 @@ static bool fmcomms1_identify(const struct osc_plugin *plugin)
 	return !!iio_context_find_device(osc_ctx, "cf-ad9122-core-lpc");
 }
 
-GSList* get_dac_dev_names(void) {
+GSList* get_dac_dev_names(const struct osc_plugin *plugin) {
 	GSList *list = NULL;
 
 	list = g_slist_append (list, (gpointer) "cf-ad9122-core-lpc");

--- a/plugins/fmcomms11.c
+++ b/plugins/fmcomms11.c
@@ -393,7 +393,7 @@ static bool fmcomms11_identify(const struct osc_plugin *plugin)
 		!!iio_context_find_device(osc_ctx, ATTN_DEVICE);
 }
 
-GSList* get_dac_dev_names(void) {
+GSList* get_dac_dev_names(const struct osc_plugin *plugin) {
 	GSList *list = NULL;
 
 	list = g_slist_append (list, (gpointer) DAC_DEVICE);

--- a/plugins/fmcomms2.c
+++ b/plugins/fmcomms2.c
@@ -2129,7 +2129,7 @@ static bool fmcomms2_identify(const struct osc_plugin *plugin)
 	return !iio_context_find_device(osc_ctx, "ad9361-phy-B");
 }
 
-GSList* get_dac_dev_names(void) {
+GSList* get_dac_dev_names(const struct osc_plugin *plugin) {
 	GSList *list = NULL;
 
 	list = g_slist_append (list, (gpointer) DDS_DEVICE);

--- a/plugins/fmcomms5.c
+++ b/plugins/fmcomms5.c
@@ -1760,7 +1760,7 @@ static bool fmcomms5_identify(const struct osc_plugin *plugin)
 	return !!dev1 && !!dds1 && !!cap1 && !!dev2 && !!dds2 && !!cap2;
 }
 
-GSList* get_dac_dev_names(void) {
+GSList* get_dac_dev_names(const struct osc_plugin *plugin) {
 	GSList *list = NULL;
 
 	list = g_slist_append (list, (gpointer) DDS_DEVICE1);

--- a/plugins/generic_dac.c
+++ b/plugins/generic_dac.c
@@ -98,7 +98,7 @@ static GSList * get_dac_dev_names(void)
 	for (node = plugin_list; node; node = g_slist_next(node)) {
 		plugin = node->data;
 		if (plugin->get_dac_dev_names)
-			dac_dev_names = g_slist_concat (dac_dev_names, plugin->get_dac_dev_names());
+			dac_dev_names = g_slist_concat (dac_dev_names, plugin->get_dac_dev_names(plugin));
 	}
 
 	return dac_dev_names;


### PR DESCRIPTION
The parameter will be used when a plugin is instantiated multiple times.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>