### PR TITLE
plugins: adrv9009: fix crash with adrv9008-1

### DIFF
--- a/plugins/adrv9009.c
+++ b/plugins/adrv9009.c
@@ -1276,23 +1276,33 @@ static GtkWidget *adrv9009_init(struct osc_plugin *plugin, GtkWidget *notebook, 
 	gtk_combo_box_set_active(GTK_COMBO_BOX(fpga_rx_frequency_available), 0);
 	gtk_combo_box_set_active(GTK_COMBO_BOX(fpga_tx_frequency_available), 0);
 
-	ch = iio_device_find_channel(cap, "voltage0_i", false);
-	if (iio_channel_find_attr(ch, "sampling_frequency_available")) {
-		iio_combo_box_init(&fpga_widgets[num_fpga++],
+	if (cap) {
+		ch = iio_device_find_channel(cap, "voltage0_i", false);
+		if (iio_channel_find_attr(ch, "sampling_frequency_available")) {
+			iio_combo_box_init(&fpga_widgets[num_fpga++],
 						   cap, ch, "sampling_frequency",
 						   "sampling_frequency_available",
 						   fpga_rx_frequency_available, NULL);
+		} else {
+			gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object(builder,
+								  "receive_frame_dma_buf")));
+		}
 	} else {
 		gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object(builder,
 								  "receive_frame_dma_buf")));
 	}
 
-	ch = iio_device_find_channel(dds, "voltage0", true);
-	if (iio_channel_find_attr(ch, "sampling_frequency_available")) {
-		iio_combo_box_init(&fpga_widgets[num_fpga++],
+	if (dds) {
+		ch = iio_device_find_channel(dds, "voltage0", true);
+		if (iio_channel_find_attr(ch, "sampling_frequency_available")) {
+			iio_combo_box_init(&fpga_widgets[num_fpga++],
 						   dds, ch, "sampling_frequency",
 						   "sampling_frequency_available",
 						   fpga_tx_frequency_available, NULL);
+		} else {
+			gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object(builder,
+								  "transmit_frame_dma_buf")));
+		}
 	} else {
 		gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object(builder,
 								  "transmit_frame_dma_buf")));

--- a/plugins/adrv9009.c
+++ b/plugins/adrv9009.c
@@ -551,6 +551,9 @@ static void int_dec_freq_update(void)
 	double freq;
 	gchar *text;
 
+	if (!cap)
+		return;
+
 	ch = iio_device_find_channel(cap, "voltage0_i", false);
 	iio_channel_attr_read_double(ch, "sampling_frequency", &freq);
 	text = g_strdup_printf ("%f", freq / mhz_scale);
@@ -559,6 +562,9 @@ static void int_dec_freq_update(void)
 	for (; i < phy_devs_count; i++)
 		gtk_label_set_text(GTK_LABEL(subcomponents[i].label_sampling_freq_rx), text);
 	g_free(text);
+
+	if (!dds)
+		return;
 
 	ch = iio_device_find_channel(dds, "voltage0", true);
 	text = g_strdup_printf ("%f", freq / mhz_scale);


### PR DESCRIPTION
The current code crashes with ADRV9008-1, since not all IIO devices are
present on that board. This crashes on adrv9009_init().

Added null-checks.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>