### PR TITLE
[RFC] plugin cleanup on init failure

### DIFF
--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -1116,35 +1116,35 @@ static GtkWidget *adrv9002_init(struct osc_plugin *plugin, GtkWidget *notebook,
 
 	priv->builder = gtk_builder_new();
 	if (!priv->builder)
-		goto error_free_priv;
+		return NULL;
 
 	priv->ctx = osc_create_context();
 	if (!priv->ctx)
-		goto error_free_priv;
+		return NULL;
 
 	priv->adrv9002 = iio_context_find_device(priv->ctx, dev_name);
 	if (!priv->adrv9002) {
 		printf("Could not find iio device:%s\n", dev_name);
-		goto error_free_ctx;
+		return NULL;
 	}
 
 	if (osc_load_glade_file(priv->builder, "adrv9002") < 0)
-		goto error_free_ctx;
+		return NULL;
 
 	priv->nbook = GTK_NOTEBOOK(notebook);
 	adrv9002_panel = GTK_WIDGET(gtk_builder_get_object(priv->builder,
 							   "adrv9002_panel"));
 	if (!adrv9002_panel)
-		goto error_free_ctx;
+		return NULL;
 
 	for (i = 0; i < ADRV9002_NUM_CHANNELS; i++) {
 		ret = adrv9002_rx_widgets_init(priv, i);
 		if (ret)
-			goto error_free_ctx;
+			return NULL;
 
 		ret = adrv9002_tx_widgets_init(priv, i);
 		if (ret)
-			goto error_free_ctx;
+			return NULL;
 	}
 	/* handle sections buttons and reload settings */
 	global = GTK_WIDGET(gtk_builder_get_object(priv->builder, "global_settings"));
@@ -1181,18 +1181,18 @@ static GtkWidget *adrv9002_init(struct osc_plugin *plugin, GtkWidget *notebook,
 	/* init temperature label */
 	temp = iio_device_find_channel(priv->adrv9002, "temp0", false);
 	if (!temp)
-		goto error_free_ctx;
+		return NULL;
 
 	adrv9002_gtk_label_init(priv, &priv->temperature, temp, "input", "temperature", 1000);
 
 	/* init dds container */
 	ret = adrv9002_dds_init(priv);
 	if (ret)
-		goto error_free_ctx;
+		return NULL;
 
 	ret = adrv9002_adc_get_name(priv);
 	if (ret)
-		goto error_free_ctx;
+		return NULL;
 
 	/* update widgets and connect signals */
 	for (i = 0; i < ADRV9002_NUM_CHANNELS; i++) {
@@ -1211,14 +1211,6 @@ static GtkWidget *adrv9002_init(struct osc_plugin *plugin, GtkWidget *notebook,
 	priv->refresh_timeout = g_timeout_add(1000, (GSourceFunc)update_display,
 					      priv);
 	return adrv9002_panel;
-
-error_free_ctx:
-	osc_destroy_context(priv->ctx);
-error_free_priv:
-	osc_plugin_context_free_resources(&priv->plugin_ctx);
-	g_free(priv);
-
-	return NULL;
 }
 
 static void update_active_page(struct osc_plugin *plugin, gint active_page,
@@ -1243,7 +1235,8 @@ static void context_destroy(struct osc_plugin *plugin, const char *ini_fn)
 	int i;
 
 	osc_plugin_context_free_resources(&priv->plugin_ctx);
-	osc_destroy_context(priv->ctx);
+	if (priv->ctx)
+		osc_destroy_context(priv->ctx);
 
 	for (i = 0; i < priv->n_dacs; i++) {
 		dac_data_manager_free(priv->dac_manager[i].dac_tx_manager);


### PR DESCRIPTION
The motivation for this was a crash provoked by a failure in initializing the adrv9002 plugin. If the plugins fails to initialize, it will do some cleanups and since this plugins provides `get_dac_dev_names()`, the generic_dac plugin will call it and thus, will try to access nonexistent data.

The reason why this is a RFC is because it's not clear to me if it is intentional that a plugin is kept around even if it fails to initialize. The natural thing to me is that if a plugin fails to initialize, then it should be removed from our plugin list and it's resources should also be cleaned....

With this change, it's clear that a plugin should not clear any data during the init callback (it might still choose to do so if it coordinates things with the `destroy()` callback). Hence, some plugins might need to be fixed to take this into account. In this series, there are already fixes for two plugins...