### PR TITLE
Plugins init cleanup 

### DIFF
--- a/osc.c
+++ b/osc.c
@@ -832,11 +832,8 @@ static void close_plugins(const char *ini_fn)
 	plugin_lib_list = NULL;
 }
 
-static void close_plugin(struct osc_plugin *plugin, const char *ini_fn, const bool do_destroy)
+static void close_plugin(struct osc_plugin *plugin)
 {
-	if (plugin->destroy && do_destroy)
-		plugin->destroy(plugin, ini_fn);
-
 	plugin_lib_list = g_slist_remove(plugin_lib_list, plugin->handle);
 	dlclose(plugin->handle);
 	plugin_list = g_slist_remove(plugin_list, plugin);
@@ -983,7 +980,7 @@ static void load_plugin_complete(gpointer data, gpointer user_data)
 
 	widget = g_thread_join(plugin->thd);
 	if (!widget) {
-		close_plugin(plugin, NULL, TRUE);
+		close_plugin(plugin);
 		return;
 	}
 
@@ -1008,8 +1005,7 @@ static void start_plugin(gpointer data, gpointer user_data)
 
 	params = malloc(sizeof(*params));
 	if (!params) {
-		/* don't call destroy since we didn't even called init! */
-		close_plugin(plugin, NULL, FALSE);
+		close_plugin(plugin);
 		return;
 	}
 
@@ -1023,7 +1019,7 @@ static void start_plugin(gpointer data, gpointer user_data)
 	} else {
 		GtkWidget *widget = init_plugin(params);
 		if (!widget) {
-			close_plugin(plugin, NULL, TRUE);
+			close_plugin(plugin);
 			return;
 		}
 		load_plugin_finish(GTK_NOTEBOOK(notebook), widget, plugin);

--- a/plugins/AD5628_1.c
+++ b/plugins/AD5628_1.c
@@ -62,8 +62,10 @@ static GtkWidget * AD5628_1_init(struct osc_plugin *plugin, GtkWidget *notebook,
 
 	builder = gtk_builder_new();
 
-	if (osc_load_glade_file(builder, "AD5628_1") < 0)
+	if (osc_load_glade_file(builder, "AD5628_1") < 0) {
+		osc_destroy_context(ctx);
 		return NULL;
+	}
 
 	AD5628_1_panel = GTK_WIDGET(gtk_builder_get_object(builder, "tablePanelAD5628_1"));
 

--- a/plugins/AD7303.c
+++ b/plugins/AD7303.c
@@ -312,12 +312,15 @@ static GtkWidget * AD7303_init(struct osc_plugin *plugin, GtkWidget *notebook, c
 		return NULL;
 
 	thread_ctx = osc_create_context();
+	if (!thread_ctx)
+		goto destroy_ctx;
+
 	dev = iio_context_find_device(thread_ctx, "ad7303");
 
 	builder = gtk_builder_new();
 
 	if (osc_load_glade_file(builder, "AD7303") < 0)
-		return NULL;
+		goto destroy_thread_ctx;
 
 	AD7303_panel = GTK_WIDGET(gtk_builder_get_object(builder, "tablePanelAD7303"));
 	btn_sine = GTK_WIDGET(gtk_builder_get_object(builder, "togBtnSine"));
@@ -378,6 +381,12 @@ static GtkWidget * AD7303_init(struct osc_plugin *plugin, GtkWidget *notebook, c
 	rx_update_values();
 
 	return AD7303_panel;
+
+destroy_thread_ctx:
+	osc_destroy_context(thread_ctx);
+destroy_ctx:
+	osc_destroy_context(ctx);
+	return NULL;
 }
 
 static void context_destroy(struct osc_plugin *plugin, const char *ini_fn)

--- a/plugins/ad6676.c
+++ b/plugins/ad6676.c
@@ -152,7 +152,7 @@ static GtkWidget * ad6676_init(struct osc_plugin *plugin, GtkWidget *notebook, c
 
 	ctx = osc_create_context();
 	if (!ctx)
-		goto init_abort;
+		return NULL;
 
 	dev = iio_context_find_device(ctx, IIO_DEVICE);
 	if (!dev) {
@@ -170,7 +170,7 @@ static GtkWidget * ad6676_init(struct osc_plugin *plugin, GtkWidget *notebook, c
 	nbook = GTK_NOTEBOOK(notebook);
 
 	if (osc_load_glade_file(builder, "ad6676") < 0)
-		return NULL;
+		goto init_abort;
 
 	ad6676_panel = GTK_WIDGET(gtk_builder_get_object(builder, "ad6676_panel"));
 	spin_adc_freq = GTK_WIDGET(gtk_builder_get_object(builder, "spin_adc_freq"));
@@ -240,8 +240,7 @@ static GtkWidget * ad6676_init(struct osc_plugin *plugin, GtkWidget *notebook, c
 	return ad6676_panel;
 
 init_abort:
-	if (ctx)
-		osc_destroy_context(ctx);
+	osc_destroy_context(ctx);
 
 	return NULL;
 }

--- a/plugins/ad9081.c
+++ b/plugins/ad9081.c
@@ -330,16 +330,16 @@ static GtkWidget *ad9081_init(struct osc_plugin *plugin, GtkWidget *notebook,
 
 	priv->ctx = osc_create_context();
 	if (!priv->ctx)
-		return NULL;
+		goto error_free_priv;
 
 	ad9081_dev = iio_context_find_device(priv->ctx, dev_name);
 	if (!ad9081_dev) {
 		printf("Could not find iio device:%s\n", dev_name);
-		return NULL;
+		goto error_free_ctx;
 	}
 
 	if (osc_load_glade_file(builder, "ad9081") < 0)
-		return NULL;
+		goto error_free_ctx;
 
 	ad9081_panel = GTK_WIDGET(gtk_builder_get_object(builder,
 							 "ad9081_panel"));
@@ -390,7 +390,7 @@ static GtkWidget *ad9081_init(struct osc_plugin *plugin, GtkWidget *notebook,
 						      ad9081_dev,
 						      in_voltage, idx);
 			if (ret)
-				return NULL;
+				goto error_free_ctx;
 
 			if (adc_freq != 0 && adc_freq < AD9081_MAX_ADC_FREQ_MHZ)
 				ad9081_adjust_main_nco(builder, idx, adc_freq,
@@ -411,7 +411,7 @@ tx_chann:
 						      ad9081_dev,
 						      out_voltage, idx);
 			if (ret)
-				return NULL;
+				goto error_free_ctx;
 
 			if (dac_freq != 0 && dac_freq < AD9081_MAX_DAC_FREQ_MHZ)
 				ad9081_adjust_main_nco(builder, idx, dac_freq,
@@ -435,7 +435,7 @@ tx_chann:
 			printf("Warning: Got %d DDS devices. We should have 1\n",
 			       devices->len);
 			g_array_free(devices, FALSE);
-			return NULL;
+			goto error_free_ctx;
 		}
 
 		dac = g_array_index(devices, struct iio_device*, 0);
@@ -445,7 +445,7 @@ tx_chann:
 			printf("%s: Failed to start dac Manager...\n",
 			       iio_device_get_name(dac));
 			g_array_free(devices, FALSE);
-			return NULL;
+			goto error_free_ctx;
 		}
 
 		dds_container = GTK_WIDGET(gtk_builder_get_object(builder,
@@ -498,6 +498,14 @@ tx_chann:
 			       G_CALLBACK(select_page_cb), priv);
 
 	return ad9081_panel;
+
+error_free_ctx:
+	osc_destroy_context(priv->ctx);
+error_free_priv:
+	osc_plugin_context_free_resources(&priv->plugin_ctx);
+	g_free(priv);
+
+	return NULL;
 }
 
 static void update_active_page(struct osc_plugin *plugin, gint active_page,
@@ -526,8 +534,7 @@ static void context_destroy(struct osc_plugin *plugin, const char *ini_fn)
 	struct plugin_private *priv = plugin->priv;
 
 	osc_plugin_context_free_resources(&priv->plugin_ctx);
-	if (priv->ctx)
-		osc_destroy_context(priv->ctx);
+	osc_destroy_context(priv->ctx);
 	if (priv->dac_tx_manager)
 		dac_data_manager_free(priv->dac_tx_manager);
 	g_free(priv);

--- a/plugins/ad9371_adv.c
+++ b/plugins/ad9371_adv.c
@@ -1096,8 +1096,10 @@ static GtkWidget * ad9371adv_init(struct osc_plugin *plugin, GtkWidget *notebook
 
 	builder = gtk_builder_new();
 
-	if (osc_load_glade_file(builder, "ad9371_adv") < 0)
+	if (osc_load_glade_file(builder, "ad9371_adv") < 0) {
+		osc_destroy_context(ctx);
 		return NULL;
+	}
 
 	ad9371adv_panel = GTK_WIDGET(gtk_builder_get_object(builder, "ad9371adv_panel"));
 	nbook = GTK_NOTEBOOK(gtk_builder_get_object(builder, "notebook"));

--- a/plugins/ad9739a.c
+++ b/plugins/ad9739a.c
@@ -192,8 +192,10 @@ static GtkWidget * ad9739a_init(struct osc_plugin *plugin, GtkWidget *notebook, 
 	}
 
 	builder = gtk_builder_new();
-	if (osc_load_glade_file(builder, "ad9739a") < 0)
+	if (osc_load_glade_file(builder, "ad9739a") < 0) {
+		osc_destroy_context(ctx);
 		return NULL;
+	}
 
 	ad9739a_panel = GTK_WIDGET(gtk_builder_get_object(builder, "ad9739a_panel"));
 	dds_container = GTK_WIDGET(gtk_builder_get_object(builder, "dds_transmit_block"));
@@ -256,12 +258,8 @@ static void save_profile(const struct osc_plugin *plugin, const char *ini_fn)
 static void context_destroy(struct osc_plugin *plugin, const char *ini_fn)
 {
 	save_profile(NULL, ini_fn);
-
-	if (dac_tx_manager) {
-		dac_data_manager_free(dac_tx_manager);
-		dac_tx_manager = NULL;
-	}
-
+	dac_data_manager_free(dac_tx_manager);
+	dac_tx_manager = NULL;
 	osc_destroy_context(ctx);
 }
 


### PR DESCRIPTION
This is the first PR to add some cleanups on the plugins `init()` callback. The fist patch actually reverts something that was added in #273 with respect with plugins cleanup. Basically, it makes only sense to call the plugin `destroy()` if it was successfully initialized. If not, its the plugin responsibility to free whatever it needs. This makes it more easier and simple to implement `destroy()` on the plugin side. The rest of the patches are doing some cleanups in case of plugin failures. Note that I'm not going into much detail in the plugins and so, I'm just fixing the more obvious leaks. This also has the goal to inherit less issues when doing `copy->pastes` for new plugins... 