### PR TITLE
Fix installation paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,17 @@ endif()
 
 install(DIRECTORY icons DESTINATION ${SHARE_DEST})
 
-foreach(plib_dest xmls filters waveforms profiles block_diagrams)
+file(GLOB PROFILES profiles/*.cmakein)
+foreach(PROFILE IN LISTS PROFILES)
+  string(REPLACE ".cmakein" "" PROFILE_TARGET ${PROFILE})
+  configure_file(${PROFILE} ${CMAKE_CURRENT_BINARY_DIR}/profiles/${PROFILE_TARGET})
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/profiles/${PROFILE_TARGET} DESTINATION ${PLIB_DEST}/profiles/)
+endforeach()
+
+file(GLOB PROFILES profiles/*.ini)
+install(FILES ${PROFILES} DESTINATION ${PLIB_DEST}/profiles/)
+
+foreach(plib_dest xmls filters waveforms block_diagrams)
 	install(DIRECTORY ${plib_dest} DESTINATION ${PLIB_DEST})
 endforeach()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ if (WIN32)
 	string(TIMESTAMP BUILD_YEAR "%Y")
 endif()
 
+include(GNUInstallDirs)
+
 # Get the GIT hash of the latest commit
 include(FindGit OPTIONAL)
 if (GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
@@ -162,6 +164,10 @@ if(CMAKE_COMPILER_IS_GNUCC)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra -Wno-unused-parameter")
 endif()
 
+# Override on distributions that do not use a global polkit prefix (e.g. NixOS)
+if(NOT DEFINED CMAKE_POLKIT_PREFIX)
+  set(CMAKE_POLKIT_PREFIX /usr)
+endif()
 
 add_library(osc ${OSC_SRC})
 target_link_libraries(osc ${LIBOSC_LIBS})
@@ -186,7 +192,7 @@ set(CMAKE_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH})
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	configure_file(org.adi.pkexec.osc.policy.cmakein ${CMAKE_CURRENT_BINARY_DIR}/org.adi.pkexec.osc.policy @ONLY)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.adi.pkexec.osc.policy
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/polkit-1/actions/)
+		DESTINATION ${CMAKE_POLKIT_PREFIX}/${CMAKE_INSTALL_DATADIR}/polkit-1/actions/)
 	# setup exec script
 	configure_file(osc-wrapper.cmakein ${CMAKE_CURRENT_SOURCE_DIR}/osc-wrapper @ONLY)
 	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/osc-wrapper
@@ -194,11 +200,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 		DESTINATION bin)
 endif()
 
-set(PLIB_DEST lib/osc)
-set(SHARE_DEST share/osc)
+set(PLIB_DEST ${CMAKE_INSTALL_LIBDIR}/osc)
+set(SHARE_DEST ${CMAKE_INSTALL_DATADIR}/osc)
 set(GLADE_FILES_DEST ${SHARE_DEST}/glade)
-
-set(PLIB_DEST lib/osc)
 
 file(GLOB GLADE_FILES glade/*.glade)
 file(GLOB ICON_FILES icons/*)
@@ -208,27 +212,27 @@ install(FILES ${GLADE_FILES} ${ICON_FILES} DESTINATION ${GLADE_FILES_DEST})
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	configure_file(adi-osc.desktop.cmakein ${CMAKE_CURRENT_BINARY_DIR}/adi-osc.desktop @ONLY)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/adi-osc.desktop
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications/)
+		DESTINATION ${CMAKE_INSTALL_DATADIR}/applications/)
 
 	# install theme icons
 	install(FILES icons/osc16.png RENAME adi-osc.png
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/16x16/apps)
+		DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/16x16/apps)
 	install(FILES icons/osc32.png RENAME adi-osc.png
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/32x32/apps)
+		DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/32x32/apps)
 	install(FILES icons/osc64.png RENAME adi-osc.png
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/64x64/apps)
+		DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/64x64/apps)
 	install(FILES icons/osc128.png RENAME adi-osc.png
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/128x128/apps)
+		DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps)
 	install(FILES icons/osc256.png RENAME adi-osc.png
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/256x256/apps)
+		DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/256x256/apps)
 	install(FILES icons/osc.svg RENAME adi-osc.svg
-		DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps)
+		DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
 
 	# This is a bit "ugly". It makes sure that the hicolor theme directory updates
 	# it's modification date. This makes sure that osc icons are loaded right away.
 	# We can also just remove this and assume the user has do this manually or run
 	# something like `gtk-update-icon-cache -f /usr/share/icons/hicolor`.
-	install(CODE "EXECUTE_PROCESS(COMMAND sh -c \"touch /usr/share/icons/hicolor\")")
+	install(CODE "EXECUTE_PROCESS(COMMAND sh -c \"touch ${CMAKE_INSTALL_FULL_DATADIR}/icons/hicolor\")")
 endif()
 
 install(DIRECTORY icons DESTINATION ${SHARE_DEST})

--- a/config.h.cmakein
+++ b/config.h.cmakein
@@ -9,14 +9,20 @@
 #define __CONFIG_H__
 
 #ifndef PREFIX
-#	define PREFIX "@CMAKE_INSTALL_PREFIX@"
+# define PREFIX "@CMAKE_INSTALL_PREFIX@"
+# define OSC_GLADE_FILE_PATH "@CMAKE_INSTALL_FULL_DATADIR@/osc/glade/"
+# define OSC_PLUGIN_PATH "@CMAKE_INSTALL_FULL_LIBDIR@/osc/"
+# define OSC_XML_PATH "@CMAKE_INSTALL_FULL_LIBDIR@/osc/xmls"
+# define OSC_FILTER_FILE_PATH "@CMAKE_INSTALL_FULL_LIBDIR@/osc/filters"
+# define OSC_WAVEFORM_FILE_PATH "@CMAKE_INSTALL_FULL_LIBDIR@/osc/waveforms"
+# define OSC_PROFILES_FILE_PATH "@CMAKE_INSTALL_FULL_LIBDIR@/osc/profiles"
+#else
+# define OSC_GLADE_FILE_PATH PREFIX "/share/osc/glade/"
+# define OSC_PLUGIN_PATH PREFIX "/lib/osc/"
+# define OSC_XML_PATH PREFIX "/lib/osc/xmls"
+# define OSC_FILTER_FILE_PATH PREFIX "/lib/osc/filters"
+# define OSC_WAVEFORM_FILE_PATH PREFIX "/lib/osc/waveforms"
+# define OSC_PROFILES_FILE_PATH PREFIX "/lib/osc/profiles"
 #endif
-
-#define OSC_GLADE_FILE_PATH PREFIX "/share/osc/glade/"
-#define OSC_PLUGIN_PATH PREFIX "/lib/osc/"
-#define OSC_XML_PATH PREFIX "/lib/osc/xmls"
-#define OSC_FILTER_FILE_PATH PREFIX "/lib/osc/filters"
-#define OSC_WAVEFORM_FILE_PATH PREFIX "/lib/osc/waveforms"
-#define OSC_PROFILES_FILE_PATH PREFIX "/lib/osc/profiles"
 
 #endif

--- a/profiles/AD-FREQCVT1_test.ini.cmakein
+++ b/profiles/AD-FREQCVT1_test.ini.cmakein
@@ -17,19 +17,19 @@ fft_pwr_offset=0.000000
 graph_type=Lines
 show_grid=1
 enable_auto_scale=1
-user_y_axis_max=5.298330
-user_y_axis_min=-111.264938
+user_y_axis_max=5.977153
+user_y_axis_min=-125.520210
 x_axis_min=-0.767906
 x_axis_max=16.126032
-y_axis_min=-111.435539
-y_axis_max=5.306454
+y_axis_min=-126.988495
+y_axis_max=6.047071
 line_thickness = 1
 plot_title = ADI IIO Oscilloscope - Capture1
 show_capture_options = 1
 plot_width = 1011
 plot_height = 877
-plot_x_pos=887
-plot_y_pos=38
+plot_x_pos=907
+plot_y_pos=0
 cf-ad9361-lpc.expanded=1
 cf-ad9361-lpc.active=1
 cf-ad9361-lpc.trigger_enabled=0
@@ -214,7 +214,7 @@ debug.ad9361-phy.adi,ensm-enable-pin-pulse-mode-enable = 0
 debug.ad9361-phy.adi,frequency-division-duplex-mode-enable = 1
 
 [AD936X]
-load_fir_filter_file = /usr/local/lib/osc/filters/LTE20_MHz.ftr
+load_fir_filter_file = @CMAKE_INSTALL_FULL_LIBDIR@/osc/filters/LTE20_MHz.ftr
 dds_mode_tx1 = 0
 dds_mode_tx2 = 0
 tx_channel_0 = 0
@@ -222,6 +222,7 @@ tx_channel_1 = 0
 tx_channel_2 = 0
 tx_channel_3 = 0
 dac_buf_filename = (null)
+up_down_converter = 1
 global_settings_show = 1
 tx_show = 1
 rx_show = 1
@@ -294,6 +295,8 @@ cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_frequency = 9279985
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_raw = 0
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_phase = 90000
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_scale = 0.000000
+adf4351-udc-rx-pmod.out_altvoltage0_frequency = 460000000
+adf4351-udc-tx-pmod.out_altvoltage0_frequency = 490000000
 ad9361-phy.out_voltage_filter_fir_en = 1
 ad9361-phy.in_voltage_filter_fir_en = 1
 ad9361-phy.in_out_voltage_filter_fir_en = 1
@@ -328,28 +331,6 @@ debug.ad9361-phy.adi,txmon-dc-tracking-enable = 0
 debug.ad9361-phy.adi,txmon-high-gain = 24
 debug.ad9361-phy.adi,txmon-low-gain = 0
 debug.ad9361-phy.adi,txmon-low-high-thresh = 37000
-debug.ad9361-phy.adi,gpo3-tx-delay-us = 0
-debug.ad9361-phy.adi,gpo3-rx-delay-us = 0
-debug.ad9361-phy.adi,gpo2-tx-delay-us = 0
-debug.ad9361-phy.adi,gpo2-rx-delay-us = 0
-debug.ad9361-phy.adi,gpo1-tx-delay-us = 0
-debug.ad9361-phy.adi,gpo1-rx-delay-us = 0
-debug.ad9361-phy.adi,gpo0-tx-delay-us = 0
-debug.ad9361-phy.adi,gpo0-rx-delay-us = 0
-debug.ad9361-phy.adi,gpo3-slave-tx-enable = 0
-debug.ad9361-phy.adi,gpo3-slave-rx-enable = 0
-debug.ad9361-phy.adi,gpo2-slave-tx-enable = 0
-debug.ad9361-phy.adi,gpo2-slave-rx-enable = 0
-debug.ad9361-phy.adi,gpo1-slave-tx-enable = 0
-debug.ad9361-phy.adi,gpo1-slave-rx-enable = 0
-debug.ad9361-phy.adi,gpo0-slave-tx-enable = 0
-debug.ad9361-phy.adi,gpo0-slave-rx-enable = 0
-debug.ad9361-phy.adi,gpo3-inactive-state-high-enable = 0
-debug.ad9361-phy.adi,gpo2-inactive-state-high-enable = 0
-debug.ad9361-phy.adi,gpo1-inactive-state-high-enable = 0
-debug.ad9361-phy.adi,gpo0-inactive-state-high-enable = 0
-debug.ad9361-phy.adi,gpo-manual-mode-enable-mask = 0
-debug.ad9361-phy.adi,gpo-manual-mode-enable = 0
 debug.ad9361-phy.adi,aux-dac2-tx-delay-us = 0
 debug.ad9361-phy.adi,aux-dac2-rx-delay-us = 0
 debug.ad9361-phy.adi,aux-dac2-active-in-alert-enable = 0
@@ -463,14 +444,11 @@ debug.ad9361-phy.adi,rx-fastlock-pincontrol-enable = 0
 debug.ad9361-phy.adi,rx-fastlock-delay-ns = 0
 debug.ad9361-phy.adi,tx-fastlock-delay-ns = 0
 debug.ad9361-phy.adi,tdd-skip-vco-cal-enable = 0
-debug.ad9361-phy.adi,tdd-use-dual-synth-mode-enable = 0
 debug.ad9361-phy.adi,ensm-enable-txnrx-control-enable = 0
 debug.ad9361-phy.adi,ensm-enable-pin-pulse-mode-enable = 0
 debug.ad9361-phy.adi,frequency-division-duplex-mode-enable = 1
 
-# 2 MHz tone
 [AD936X]
-ad9361-phy.out_altvoltage1_TX_LO_frequency = 2400000000
 ad9361-phy.out_altvoltage1_TX_LO_external = 0
 ad9361-phy.out_voltage_rf_bandwidth = 19365438
 ad9361-phy.out_voltage_filter_fir_en = 0
@@ -490,7 +468,6 @@ ad9361-phy.in_voltage_rf_bandwidth = 19365514
 ad9361-phy.in_voltage_rf_dc_offset_tracking_en = 1
 ad9361-phy.in_voltage_quadrature_tracking_en = 1
 ad9361-phy.in_voltage_filter_fir_en = 0
-ad9361-phy.out_altvoltage0_RX_LO_frequency = 2400000000
 ad9361-phy.out_altvoltage0_RX_LO_external = 0
 ad9361-phy.in_voltage0_gain_control_mode = manual
 ad9361-phy.in_voltage0_rf_port_select = A_BALANCED
@@ -500,12 +477,10 @@ ad9361-phy.in_voltage_rf_bandwidth = 19365514
 ad9361-phy.in_voltage_rf_dc_offset_tracking_en = 1
 ad9361-phy.in_voltage_quadrature_tracking_en = 1
 ad9361-phy.in_voltage_filter_fir_en = 0
-ad9361-phy.out_voltage1_hardwaregain = -20.000000 dB
 ad9361-phy.out_voltage_rf_bandwidth = 19365438
 ad9361-phy.out_voltage_filter_fir_en = 0
 ad9361-phy.out_voltage_sampling_frequency = 30720000
 ad9361-phy.out_voltage0_rf_port_select = A
-ad9361-phy.out_voltage0_hardwaregain = -20.000000 dB
 ad9361-phy.out_voltage_rf_bandwidth = 19365438
 ad9361-phy.out_voltage_filter_fir_en = 0
 ad9361-phy.out_voltage_sampling_frequency = 30720000
@@ -514,6 +489,8 @@ ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920
 ad9361-phy.ensm_mode = fdd
 ad9361-phy.in_out_voltage_filter_fir_en = 0
+
+# 2 MHz tone
 cf-ad9361-dds-core-lpc.out_altvoltage0_TX1_I_F1_phase = 90000
 cf-ad9361-dds-core-lpc.out_altvoltage0_TX1_I_F1_scale = 1.000000
 cf-ad9361-dds-core-lpc.out_altvoltage0_TX1_I_F1_frequency = 2000186
@@ -554,11 +531,23 @@ tx_channel_0 = 0
 tx_channel_1 = 0
 tx_channel_2 = 0
 tx_channel_3 = 0
-up_down_converter = 0
+up_down_converter = 1
 global_settings_show = 1
 tx_show = 1
 rx_show = 1
 fpga_show = 1
+
+# attenuation 20 dB
+ad9361-phy.out_voltage1_hardwaregain = -20.000000 dB
+ad9361-phy.out_voltage0_hardwaregain = -20.000000 dB
+ad9361-phy.in_voltage1_hardwaregain = 1.000000 dB
+ad9361-phy.in_voltage0_hardwaregain = 1.000000 dB
+# 20 MHz LO
+ad9361-phy.out_altvoltage1_TX_LO_frequency = 370000000
+ad9361-phy.out_altvoltage0_RX_LO_frequency = 340000000
+adf4351-udc-tx-pmod.out_altvoltage0_frequency = 390000000
+adf4351-udc-rx-pmod.out_altvoltage0_frequency = 360000000
+SYNC_RELOAD = 1
 
 [IIO Oscilloscope - Capture Window1]
 domain=fft
@@ -640,11 +629,40 @@ test.marker.1 = -120.0 -55.0
 # 2st Harmonic
 test.marker.2 = -120.0 -55.0
 # 3nd Harmonic
-test.marker.3 = -90.0 -40.0
+test.marker.3 = -120.0 -55.0
 # 4th Harmonic
 test.marker.4 = -120.0 -55.0
 # 5th Harmonic
-test.marker.5 = -90.0 -40.0
+test.marker.5 = -120.0 -45.0
+
+[AD936X]
+# attenuation 25 dB
+ad9361-phy.out_voltage1_hardwaregain = -25.000000 dB
+ad9361-phy.out_voltage0_hardwaregain = -25.000000 dB
+ad9361-phy.in_voltage1_hardwaregain = 1.000000 dB
+ad9361-phy.in_voltage0_hardwaregain = 1.000000 dB
+# 100 MHz LO
+ad9361-phy.out_altvoltage1_TX_LO_frequency = 370000000
+ad9361-phy.out_altvoltage0_RX_LO_frequency = 340000000
+adf4351-udc-tx-pmod.out_altvoltage0_frequency = 470000000
+adf4351-udc-rx-pmod.out_altvoltage0_frequency = 440000000
+SYNC_RELOAD = 1
+
+[IIO Oscilloscope - Capture Window1]
+cycle = 8000
+
+# look at the markers - Fundamental
+test.marker.0 = -20.0 0.0
+# DC
+test.marker.1 = -120.0 -45.0
+# 2st Harmonic
+test.marker.2 = -120.0 -45.0
+# 3nd Harmonic
+test.marker.3 = -120.0 -45.0
+# 4th Harmonic
+test.marker.4 = -120.0 -55.0
+# 5th Harmonic
+test.marker.5 = -120.0 -45.0
 
 [AD936X]
 # 8 MHz tone
@@ -652,6 +670,47 @@ cf-ad9361-dds-core-lpc.out_altvoltage0_TX1_I_F1_frequency = 8000278
 cf-ad9361-dds-core-lpc.out_altvoltage4_TX2_I_F1_frequency = 8000278
 cf-ad9361-dds-core-lpc.out_altvoltage6_TX2_Q_F1_frequency = 8000278
 cf-ad9361-dds-core-lpc.out_altvoltage2_TX1_Q_F1_frequency = 8000278
+
+# attenuation 20 dB
+ad9361-phy.out_voltage1_hardwaregain = -20.000000 dB
+ad9361-phy.out_voltage0_hardwaregain = -20.000000 dB
+ad9361-phy.in_voltage1_hardwaregain = 1.000000 dB
+ad9361-phy.in_voltage0_hardwaregain = 1.000000 dB
+
+# 20 MHz LO
+ad9361-phy.out_altvoltage1_TX_LO_frequency = 370000000
+ad9361-phy.out_altvoltage0_RX_LO_frequency = 340000000
+adf4351-udc-tx-pmod.out_altvoltage0_frequency = 390000000
+adf4351-udc-rx-pmod.out_altvoltage0_frequency = 360000000
+SYNC_RELOAD = 1
+
+[IIO Oscilloscope - Capture Window1]
+cycle = 8000
+
+# look at the markers - Fundamental
+test.marker.0 = -20.0 0.0
+# DC
+test.marker.1 = -120.0 -45.0
+# 2st Harmonic
+test.marker.2 = -120.0 -55.0
+# 3nd Harmonic
+test.marker.3 = -120.0 -55.0
+# 4th Harmonic
+test.marker.4 = -120.0 -55.0
+# 5th Harmonic
+test.marker.5 = -120.0 -55.0
+
+[AD936X]
+# attenuation 25 dB
+ad9361-phy.out_voltage1_hardwaregain = -25.000000 dB
+ad9361-phy.out_voltage0_hardwaregain = -25.000000 dB
+ad9361-phy.in_voltage1_hardwaregain = 1.000000 dB
+ad9361-phy.in_voltage0_hardwaregain = 1.000000 dB
+# 100 MHz LO
+ad9361-phy.out_altvoltage1_TX_LO_frequency = 370000000
+ad9361-phy.out_altvoltage0_RX_LO_frequency = 340000000
+adf4351-udc-tx-pmod.out_altvoltage0_frequency = 470000000
+adf4351-udc-rx-pmod.out_altvoltage0_frequency = 440000000
 SYNC_RELOAD = 1
 
 [IIO Oscilloscope - Capture Window1]
@@ -662,13 +721,14 @@ test.marker.0 = -20.0 0.0
 # DC
 test.marker.1 = -120.0 -55.0
 # 2st Harmonic
-test.marker.2 = -120.0 -45.0
+test.marker.2 = -120.0 -55.0
 # 3nd Harmonic
-test.marker.3 = -120.0 -45.0
+test.marker.3 = -120.0 -55.0
 # 4th Harmonic
-test.marker.4 = -130.0 -80.0
+test.marker.4 = -120.0 -55.0
 # 5th Harmonic
-test.marker.5 = -120.0 -60.0
+test.marker.5 = -120.0 -55.0
 
+[IIO Oscilloscope - Capture Window1]
 test.message = All tests passed - Ship it
 quit = 1

--- a/profiles/AD-TRXBOOST1_test.ini.cmakein
+++ b/profiles/AD-TRXBOOST1_test.ini.cmakein
@@ -17,19 +17,19 @@ fft_pwr_offset=0.000000
 graph_type=Lines
 show_grid=1
 enable_auto_scale=1
-user_y_axis_max=5.977153
-user_y_axis_min=-125.520210
+user_y_axis_max=5.298330
+user_y_axis_min=-111.264938
 x_axis_min=-0.767906
 x_axis_max=16.126032
-y_axis_min=-126.988495
-y_axis_max=6.047071
+y_axis_min=-111.435539
+y_axis_max=5.306454
 line_thickness = 1
 plot_title = ADI IIO Oscilloscope - Capture1
 show_capture_options = 1
 plot_width = 1011
 plot_height = 877
-plot_x_pos=907
-plot_y_pos=0
+plot_x_pos=887
+plot_y_pos=38
 cf-ad9361-lpc.expanded=1
 cf-ad9361-lpc.active=1
 cf-ad9361-lpc.trigger_enabled=0
@@ -214,7 +214,7 @@ debug.ad9361-phy.adi,ensm-enable-pin-pulse-mode-enable = 0
 debug.ad9361-phy.adi,frequency-division-duplex-mode-enable = 1
 
 [AD936X]
-load_fir_filter_file = /usr/local/lib/osc/filters/LTE20_MHz.ftr
+load_fir_filter_file = @CMAKE_INSTALL_FULL_LIBDIR@/osc/filters/LTE20_MHz.ftr
 dds_mode_tx1 = 0
 dds_mode_tx2 = 0
 tx_channel_0 = 0
@@ -222,7 +222,6 @@ tx_channel_1 = 0
 tx_channel_2 = 0
 tx_channel_3 = 0
 dac_buf_filename = (null)
-up_down_converter = 1
 global_settings_show = 1
 tx_show = 1
 rx_show = 1
@@ -295,8 +294,6 @@ cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_frequency = 9279985
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_raw = 0
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_phase = 90000
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_scale = 0.000000
-adf4351-udc-rx-pmod.out_altvoltage0_frequency = 460000000
-adf4351-udc-tx-pmod.out_altvoltage0_frequency = 490000000
 ad9361-phy.out_voltage_filter_fir_en = 1
 ad9361-phy.in_voltage_filter_fir_en = 1
 ad9361-phy.in_out_voltage_filter_fir_en = 1
@@ -331,6 +328,28 @@ debug.ad9361-phy.adi,txmon-dc-tracking-enable = 0
 debug.ad9361-phy.adi,txmon-high-gain = 24
 debug.ad9361-phy.adi,txmon-low-gain = 0
 debug.ad9361-phy.adi,txmon-low-high-thresh = 37000
+debug.ad9361-phy.adi,gpo3-tx-delay-us = 0
+debug.ad9361-phy.adi,gpo3-rx-delay-us = 0
+debug.ad9361-phy.adi,gpo2-tx-delay-us = 0
+debug.ad9361-phy.adi,gpo2-rx-delay-us = 0
+debug.ad9361-phy.adi,gpo1-tx-delay-us = 0
+debug.ad9361-phy.adi,gpo1-rx-delay-us = 0
+debug.ad9361-phy.adi,gpo0-tx-delay-us = 0
+debug.ad9361-phy.adi,gpo0-rx-delay-us = 0
+debug.ad9361-phy.adi,gpo3-slave-tx-enable = 0
+debug.ad9361-phy.adi,gpo3-slave-rx-enable = 0
+debug.ad9361-phy.adi,gpo2-slave-tx-enable = 0
+debug.ad9361-phy.adi,gpo2-slave-rx-enable = 0
+debug.ad9361-phy.adi,gpo1-slave-tx-enable = 0
+debug.ad9361-phy.adi,gpo1-slave-rx-enable = 0
+debug.ad9361-phy.adi,gpo0-slave-tx-enable = 0
+debug.ad9361-phy.adi,gpo0-slave-rx-enable = 0
+debug.ad9361-phy.adi,gpo3-inactive-state-high-enable = 0
+debug.ad9361-phy.adi,gpo2-inactive-state-high-enable = 0
+debug.ad9361-phy.adi,gpo1-inactive-state-high-enable = 0
+debug.ad9361-phy.adi,gpo0-inactive-state-high-enable = 0
+debug.ad9361-phy.adi,gpo-manual-mode-enable-mask = 0
+debug.ad9361-phy.adi,gpo-manual-mode-enable = 0
 debug.ad9361-phy.adi,aux-dac2-tx-delay-us = 0
 debug.ad9361-phy.adi,aux-dac2-rx-delay-us = 0
 debug.ad9361-phy.adi,aux-dac2-active-in-alert-enable = 0
@@ -444,11 +463,14 @@ debug.ad9361-phy.adi,rx-fastlock-pincontrol-enable = 0
 debug.ad9361-phy.adi,rx-fastlock-delay-ns = 0
 debug.ad9361-phy.adi,tx-fastlock-delay-ns = 0
 debug.ad9361-phy.adi,tdd-skip-vco-cal-enable = 0
+debug.ad9361-phy.adi,tdd-use-dual-synth-mode-enable = 0
 debug.ad9361-phy.adi,ensm-enable-txnrx-control-enable = 0
 debug.ad9361-phy.adi,ensm-enable-pin-pulse-mode-enable = 0
 debug.ad9361-phy.adi,frequency-division-duplex-mode-enable = 1
 
+# 2 MHz tone
 [AD936X]
+ad9361-phy.out_altvoltage1_TX_LO_frequency = 2400000000
 ad9361-phy.out_altvoltage1_TX_LO_external = 0
 ad9361-phy.out_voltage_rf_bandwidth = 19365438
 ad9361-phy.out_voltage_filter_fir_en = 0
@@ -468,6 +490,7 @@ ad9361-phy.in_voltage_rf_bandwidth = 19365514
 ad9361-phy.in_voltage_rf_dc_offset_tracking_en = 1
 ad9361-phy.in_voltage_quadrature_tracking_en = 1
 ad9361-phy.in_voltage_filter_fir_en = 0
+ad9361-phy.out_altvoltage0_RX_LO_frequency = 2400000000
 ad9361-phy.out_altvoltage0_RX_LO_external = 0
 ad9361-phy.in_voltage0_gain_control_mode = manual
 ad9361-phy.in_voltage0_rf_port_select = A_BALANCED
@@ -477,10 +500,12 @@ ad9361-phy.in_voltage_rf_bandwidth = 19365514
 ad9361-phy.in_voltage_rf_dc_offset_tracking_en = 1
 ad9361-phy.in_voltage_quadrature_tracking_en = 1
 ad9361-phy.in_voltage_filter_fir_en = 0
+ad9361-phy.out_voltage1_hardwaregain = -20.000000 dB
 ad9361-phy.out_voltage_rf_bandwidth = 19365438
 ad9361-phy.out_voltage_filter_fir_en = 0
 ad9361-phy.out_voltage_sampling_frequency = 30720000
 ad9361-phy.out_voltage0_rf_port_select = A
+ad9361-phy.out_voltage0_hardwaregain = -20.000000 dB
 ad9361-phy.out_voltage_rf_bandwidth = 19365438
 ad9361-phy.out_voltage_filter_fir_en = 0
 ad9361-phy.out_voltage_sampling_frequency = 30720000
@@ -489,8 +514,6 @@ ad9361-phy.dcxo_tune_coarse = 8
 ad9361-phy.dcxo_tune_fine = 5920
 ad9361-phy.ensm_mode = fdd
 ad9361-phy.in_out_voltage_filter_fir_en = 0
-
-# 2 MHz tone
 cf-ad9361-dds-core-lpc.out_altvoltage0_TX1_I_F1_phase = 90000
 cf-ad9361-dds-core-lpc.out_altvoltage0_TX1_I_F1_scale = 1.000000
 cf-ad9361-dds-core-lpc.out_altvoltage0_TX1_I_F1_frequency = 2000186
@@ -531,23 +554,11 @@ tx_channel_0 = 0
 tx_channel_1 = 0
 tx_channel_2 = 0
 tx_channel_3 = 0
-up_down_converter = 1
+up_down_converter = 0
 global_settings_show = 1
 tx_show = 1
 rx_show = 1
 fpga_show = 1
-
-# attenuation 20 dB
-ad9361-phy.out_voltage1_hardwaregain = -20.000000 dB
-ad9361-phy.out_voltage0_hardwaregain = -20.000000 dB
-ad9361-phy.in_voltage1_hardwaregain = 1.000000 dB
-ad9361-phy.in_voltage0_hardwaregain = 1.000000 dB
-# 20 MHz LO
-ad9361-phy.out_altvoltage1_TX_LO_frequency = 370000000
-ad9361-phy.out_altvoltage0_RX_LO_frequency = 340000000
-adf4351-udc-tx-pmod.out_altvoltage0_frequency = 390000000
-adf4351-udc-rx-pmod.out_altvoltage0_frequency = 360000000
-SYNC_RELOAD = 1
 
 [IIO Oscilloscope - Capture Window1]
 domain=fft
@@ -629,40 +640,11 @@ test.marker.1 = -120.0 -55.0
 # 2st Harmonic
 test.marker.2 = -120.0 -55.0
 # 3nd Harmonic
-test.marker.3 = -120.0 -55.0
+test.marker.3 = -90.0 -40.0
 # 4th Harmonic
 test.marker.4 = -120.0 -55.0
 # 5th Harmonic
-test.marker.5 = -120.0 -45.0
-
-[AD936X]
-# attenuation 25 dB
-ad9361-phy.out_voltage1_hardwaregain = -25.000000 dB
-ad9361-phy.out_voltage0_hardwaregain = -25.000000 dB
-ad9361-phy.in_voltage1_hardwaregain = 1.000000 dB
-ad9361-phy.in_voltage0_hardwaregain = 1.000000 dB
-# 100 MHz LO
-ad9361-phy.out_altvoltage1_TX_LO_frequency = 370000000
-ad9361-phy.out_altvoltage0_RX_LO_frequency = 340000000
-adf4351-udc-tx-pmod.out_altvoltage0_frequency = 470000000
-adf4351-udc-rx-pmod.out_altvoltage0_frequency = 440000000
-SYNC_RELOAD = 1
-
-[IIO Oscilloscope - Capture Window1]
-cycle = 8000
-
-# look at the markers - Fundamental
-test.marker.0 = -20.0 0.0
-# DC
-test.marker.1 = -120.0 -45.0
-# 2st Harmonic
-test.marker.2 = -120.0 -45.0
-# 3nd Harmonic
-test.marker.3 = -120.0 -45.0
-# 4th Harmonic
-test.marker.4 = -120.0 -55.0
-# 5th Harmonic
-test.marker.5 = -120.0 -45.0
+test.marker.5 = -90.0 -40.0
 
 [AD936X]
 # 8 MHz tone
@@ -670,47 +652,6 @@ cf-ad9361-dds-core-lpc.out_altvoltage0_TX1_I_F1_frequency = 8000278
 cf-ad9361-dds-core-lpc.out_altvoltage4_TX2_I_F1_frequency = 8000278
 cf-ad9361-dds-core-lpc.out_altvoltage6_TX2_Q_F1_frequency = 8000278
 cf-ad9361-dds-core-lpc.out_altvoltage2_TX1_Q_F1_frequency = 8000278
-
-# attenuation 20 dB
-ad9361-phy.out_voltage1_hardwaregain = -20.000000 dB
-ad9361-phy.out_voltage0_hardwaregain = -20.000000 dB
-ad9361-phy.in_voltage1_hardwaregain = 1.000000 dB
-ad9361-phy.in_voltage0_hardwaregain = 1.000000 dB
-
-# 20 MHz LO
-ad9361-phy.out_altvoltage1_TX_LO_frequency = 370000000
-ad9361-phy.out_altvoltage0_RX_LO_frequency = 340000000
-adf4351-udc-tx-pmod.out_altvoltage0_frequency = 390000000
-adf4351-udc-rx-pmod.out_altvoltage0_frequency = 360000000
-SYNC_RELOAD = 1
-
-[IIO Oscilloscope - Capture Window1]
-cycle = 8000
-
-# look at the markers - Fundamental
-test.marker.0 = -20.0 0.0
-# DC
-test.marker.1 = -120.0 -45.0
-# 2st Harmonic
-test.marker.2 = -120.0 -55.0
-# 3nd Harmonic
-test.marker.3 = -120.0 -55.0
-# 4th Harmonic
-test.marker.4 = -120.0 -55.0
-# 5th Harmonic
-test.marker.5 = -120.0 -55.0
-
-[AD936X]
-# attenuation 25 dB
-ad9361-phy.out_voltage1_hardwaregain = -25.000000 dB
-ad9361-phy.out_voltage0_hardwaregain = -25.000000 dB
-ad9361-phy.in_voltage1_hardwaregain = 1.000000 dB
-ad9361-phy.in_voltage0_hardwaregain = 1.000000 dB
-# 100 MHz LO
-ad9361-phy.out_altvoltage1_TX_LO_frequency = 370000000
-ad9361-phy.out_altvoltage0_RX_LO_frequency = 340000000
-adf4351-udc-tx-pmod.out_altvoltage0_frequency = 470000000
-adf4351-udc-rx-pmod.out_altvoltage0_frequency = 440000000
 SYNC_RELOAD = 1
 
 [IIO Oscilloscope - Capture Window1]
@@ -721,14 +662,13 @@ test.marker.0 = -20.0 0.0
 # DC
 test.marker.1 = -120.0 -55.0
 # 2st Harmonic
-test.marker.2 = -120.0 -55.0
+test.marker.2 = -120.0 -45.0
 # 3nd Harmonic
-test.marker.3 = -120.0 -55.0
+test.marker.3 = -120.0 -45.0
 # 4th Harmonic
-test.marker.4 = -120.0 -55.0
+test.marker.4 = -130.0 -80.0
 # 5th Harmonic
-test.marker.5 = -120.0 -55.0
+test.marker.5 = -120.0 -60.0
 
-[IIO Oscilloscope - Capture Window1]
 test.message = All tests passed - Ship it
 quit = 1

--- a/profiles/PZSDR2_2400TDD_test.ini.cmakein
+++ b/profiles/PZSDR2_2400TDD_test.ini.cmakein
@@ -236,7 +236,7 @@ debug.ad9361-phy.initialize=1
 
 [AD936X]
 # load filter LTE20_MHz.ftr
-load_fir_filter_file = /usr/local/lib/osc/filters/LTE20_MHz.ftr
+load_fir_filter_file = @CMAKE_INSTALL_FULL_LIBDIR@/osc/filters/LTE20_MHz.ftr
 ad9361-phy.out_altvoltage1_TX_LO_frequency = 2400000000
 ad9361-phy.out_altvoltage1_TX_LO_external = 0
 ad9361-phy.out_voltage_rf_bandwidth = 19365438
@@ -718,7 +718,7 @@ debug.ad9361-phy.initialize=1
 
 [AD936X]
 # load filter LTE20_MHZ.ftr
-load_fir_filter_file = /usr/local/lib/osc/filters/LTE20_MHz.ftr
+load_fir_filter_file = @CMAKE_INSTALL_FULL_LIBDIR@/osc/filters/LTE20_MHz.ftr
 ad9361-phy.out_altvoltage1_TX_LO_frequency = 2400000000
 ad9361-phy.out_altvoltage1_TX_LO_external = 0
 ad9361-phy.out_voltage_rf_bandwidth = 19365438
@@ -911,7 +911,7 @@ cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_frequency = 9279985
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_raw = 1
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_phase = 90000
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_scale = 0.000000
-load_fir_filter_file = /usr/local/lib/osc/filters/LTE20_MHz.ftr
+load_fir_filter_file = @CMAKE_INSTALL_FULL_LIBDIR@/osc/filters/LTE20_MHz.ftr
 # turn on TX outputs
 dds_mode_tx1 = 1
 dds_mode_tx2 = 1
@@ -1067,7 +1067,7 @@ cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_frequency = 9279985
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_raw = 1
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_phase = 90000
 cf-ad9361-dds-core-lpc.out_altvoltage1_TX1_I_F2_scale = 0.000000
-load_fir_filter_file = /usr/local/lib/osc/filters/LTE20_MHz.ftr
+load_fir_filter_file = @CMAKE_INSTALL_FULL_LIBDIR@/osc/filters/LTE20_MHz.ftr
 dds_mode_tx1 = 1
 dds_mode_tx2 = 1
 tx_channel_0 = 0


### PR DESCRIPTION
polkit needs its own prefix:
- FHS distributions have polkit actions in /usr regardless of installation path
- non-FHS distributions don't and need this configurable

Convert profiles/*.ini files to *.cmakein when they reference other files and
need to honor CMAKE_INSTALL_PREFIX.

Fixes problems with #277 