### PR TITLE
plugins: adrv9009: Update plugin identify function for FMCOMMS8

### DIFF
--- a/plugins/adrv9009.c
+++ b/plugins/adrv9009.c
@@ -1817,8 +1817,9 @@ static bool adrv9009_identify(const struct osc_plugin *plugin)
 {
 	/* Use the OSC's IIO context just to detect the devices */
 	struct iio_context *osc_ctx = get_context_from_osc();
+	GArray *phy_adrv9009_devs = get_iio_devices_starting_with(osc_ctx, PHY_DEVICE);
 
-	return !!iio_context_find_device(osc_ctx, PHY_DEVICE);
+	return !!phy_adrv9009_devs->len;
 }
 
 GSList* get_dac_dev_names(const struct osc_plugin *plugin) {


### PR DESCRIPTION
When FMCOMMS8 is used standalone, available devices are "adrv9009-phy-c"
and "adrv9009-phy-d". The previous implementation was searching exactly
for "adrv9009-phy".

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>