### PR TITLE
ci,azure-pipelines: add first integration with Azure (for Linux & Mac only right now)

### DIFF
--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -3,18 +3,16 @@
 . CI/travis/lib.sh
 . CI/travis/before_install_lib.sh
 
-brew unlink python@2
-
 brew_install_if_not_exists cmake fftw libmatio \
 	libxml2 pkg-config libusb gtk+ gtkdatabox \
 	jansson glib curl openssl@1.1 \
-	gettext libserialport
+	gettext libserialport python
 
-for pkg in gettext ; do
-	brew link --overwrite --force $pkg
-done
-
-if [ "$TRAVIS" == "true" ] ; then
+if [ -n "$PACKAGE_TO_INSTALL" ] ; then
+	for file in $PACKAGE_TO_INSTALL ; do
+		sudo installer -pkg "${file}" -target /
+	done
+elif [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
 	for pkg in libiio libad9361-iio ; do
 		wget http://swdownloads.analog.com/cse/travis_builds/master_latest_${pkg}${LDIST}.pkg
 		sudo installer -pkg master_latest_${pkg}${LDIST}.pkg -target /
@@ -24,4 +22,3 @@ else
 
 	cmake_build_git "libad9361-iio" "https://github.com/analogdevicesinc/libad9361-iio" "" "-DLIBIIO_INCLUDEDIR:PATH=$STAGINGDIR/include -DLIBIIO_LIBRARIES:FILEPATH=$STAGINGDIR/lib/libiio.dylib"
 fi
-

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -6,49 +6,47 @@
 handle_centos() {
 
 	# First EPEL stuff
-	yum install -y epel-release
+	yum install -y epel-release yum-utils
+	yum config-manager --set-enabled powertools
 
 	# FIXME: see about adding `libserialport-dev` from EPEL ; maybe libusb-1.0.0-devel...
 	yum -y groupinstall 'Development Tools'
 	yum -y install cmake libxml2-devel libcurl-devel glib2-devel \
 		fftw-devel libusb1-devel jansson-devel cmake gtk2-devel \
 		bison flex doxygen matio-devel libaio-devel libtool \
-		libavahi-client-devel
+		avahi-devel
 
-	if [ "$TRAVIS" = "true" ] || [ "$INSIDE_DOCKER" = "1" ] ; then
+	if [ -n "$PACKAGE_TO_INSTALL" ] ; then
+		sudo yum localinstall -y $PACKAGE_TO_INSTALL
+		STAGINGDIR=/usr
+	elif [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
 		for pkg in libiio libad9361-iio ; do
 			wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_${pkg}${LDIST}.rpm
 			sudo yum localinstall -y ./${LIBIIO_BRANCH}_latest_${pkg}${LDIST}.rpm
 		done
-
-		LIBDIR="--libdir=/usr/lib64"
-		# XXX: There is no gtkdatabox available in CentOS or EPEL....
-		make_build_wget "gtkdatabox-0.9.3.0" "https://sourceforge.net/projects/gtkdatabox/files/gtkdatabox/0.9.3.0/gtkdatabox-0.9.3.0.tar.gz/download"
 	else
 		cmake_build_git "libiio" "https://github.com/analogdevicesinc/libiio" "" "-DINSTALL_UDEV_RULE:BOOL=OFF"
 		cmake_build_git "libad9361-iio" "https://github.com/analogdevicesinc/libad9361-iio" "" "-DLIBIIO_INCLUDEDIR:PATH=$STAGINGDIR/include -DLIBIIO_LIBRARIES:FILEPATH=$STAGINGDIR/lib/libiio.so"
 	fi
+
+	# XXX: There is no gtkdatabox available in CentOS or EPEL....
+	make_build_wget "gtkdatabox-0.9.3.0" "https://sourceforge.net/projects/gtkdatabox/files/gtkdatabox/0.9.3.0/gtkdatabox-0.9.3.0.tar.gz/download"
 }
 
-handle_centos_docker() {
-	prepare_docker_image "centos:centos${OS_VERSION}"
-}
-
-handle_ubuntu_docker() {
-	prepare_docker_image "ubuntu:${OS_VERSION}"
+handle_generic_docker() {
+	prepare_docker_image
 }
 
 handle_default() {
 	sudo apt-get -qq update
-	sudo apt-get install -y build-essential libxml2-dev libcurl4-openssl-dev \
-		libmatio-dev libglib2.0-dev libfftw3-dev libusb-1.0-0-dev libjansson-dev \
-		cmake libgtk2.0-dev libgtkdatabox-dev bison flex doxygen libaio-dev \
-		libavahi-client-dev
-	if [ `sudo apt-cache search libserialport-dev | wc -l` -gt 0 ] ; then
-		sudo apt-get install -y libserialport-dev
-	fi
+	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential libxml2-dev \
+		libcurl4-openssl-dev libmatio-dev libglib2.0-dev libfftw3-dev libusb-1.0-0-dev \
+		libjansson-dev cmake libgtk2.0-dev libgtkdatabox-dev bison flex doxygen \
+		libaio-dev libavahi-client-dev libserialport-dev
 
-	if [ "$TRAVIS" = "true" ] || [ "$INSIDE_DOCKER" = "1" ] ; then
+	if [ -n "$PACKAGE_TO_INSTALL" ] ; then
+		sudo dpkg -i $PACKAGE_TO_INSTALL
+	elif [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
 		for pkg in libiio libad9361-iio ; do
 			wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_${pkg}${LDIST}.deb
 			sudo dpkg -i ./${LIBIIO_BRANCH}_latest_${pkg}${LDIST}.deb
@@ -59,8 +57,14 @@ handle_default() {
 	fi
 }
 
-LIBNAME="iio-oscilloscope"
-OS_TYPE=${1:-default}
-OS_VERSION="$2"
+handle_ubuntu() {
+	handle_default
+}
 
-handle_${OS_TYPE}
+handle_debian() {
+	handle_default
+}
+
+setup_build_type_env_vars
+
+handle_${BUILD_TYPE}

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -2,14 +2,6 @@
 
 TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR:-'./'}
 
-WORKDIR="${PWD}/deps"
-mkdir -p "$WORKDIR"
-if [ "$TRAVIS" = "true" ] || [ "$INSIDE_DOCKER" = "1" ] ; then
-	STAGINGDIR=/usr
-else
-	STAGINGDIR="${WORKDIR}/staging"
-fi
-
 LIBIIO_BRANCH=master
 
 command_exists() {
@@ -48,6 +40,8 @@ ensure_command_exists sudo
 }
 
 . ${TRAVIS_BUILD_DIR}/build/lib.sh
+
+INSIDE_DOCKER_TRAVIS_CI_ENV="$INSIDE_DOCKER_TRAVIS_CI_ENV PACKAGE_TO_INSTALL"
 
 if [ -z "${LDIST}" -a -f "build/.LDIST" ] ; then
 	export LDIST="-$(cat build/.LDIST)"

--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -1,7 +1,5 @@
 #!/bin/sh -e
 
-export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
-
 export CFLAGS="-Wno-deprecated"
 
 . CI/travis/make_linux

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -10,7 +10,7 @@ fi
 handle_default() {
 	mkdir -p build
 	cd build
-	if [ "$TRAVIS" = "true" ] || [ "$INSIDE_DOCKER" = "1" ] ; then
+	if [ -n "$PACKAGE_TO_INSTALL" ] || [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
 		cmake ..
 		make
 	else
@@ -26,18 +26,18 @@ handle_centos() {
 	handle_default
 }
 
-handle_centos_docker() {
-        run_docker_script inside_docker.sh \
-                "centos:centos${OS_VERSION}" "centos"
+handle_ubuntu() {
+	handle_default
 }
 
-handle_ubuntu_docker() {
-        run_docker_script inside_docker.sh \
-                "ubuntu:${OS_VERSION}"
+handle_debian() {
+	handle_default
 }
 
-LIBNAME="iio-oscilloscope"
-OS_TYPE=${1:-default}
-OS_VERSION="$2"
+handle_generic_docker() {
+	run_docker_script inside_docker.sh
+}
 
-handle_${OS_TYPE}
+setup_build_type_env_vars
+
+handle_${BUILD_TYPE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ link_directories(${CMAKE_PREFIX_PATH}/lib)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	add_compile_options("-F/Library/Frameworks/")
 	link_libraries("-F/Library/Frameworks/")
+	# Fix linking on 10.14+ with Homebrew. See https://stackoverflow.com/questions/54068035
+	LINK_DIRECTORIES(/usr/local/lib)
 endif()
 
 add_definitions(-Dlinux -D_GNU_SOURCE 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,118 @@
+variables:
+  libiioPipelineId: 9
+  libad9361iioPipelineId: 10
+
+trigger:
+- main
+- master
+- staging/*
+- 20*
+
+pr:
+- main
+- master
+- 20*
+
+jobs:
+- job: LinuxBuilds
+  strategy:
+    matrix:
+      centos_8_x86_64:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'centos_docker'
+        OS_VERSION: centos8
+        artifactName: 'Linux-CentOS-8-x86_64'
+        PACKAGE_TO_INSTALL: 'build/*.rpm'
+      ubuntu_18_04_x86_64:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'ubuntu_docker'
+        OS_VERSION: bionic
+        artifactName: 'Linux-Ubuntu-18.04-x86_64'
+        PACKAGE_TO_INSTALL: 'build/*.deb'
+      ubuntu_20_04_x86_64:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'ubuntu_docker'
+        OS_VERSION: focal
+        artifactName: 'Linux-Ubuntu-20.04-x86_64'
+        PACKAGE_TO_INSTALL: 'build/*.deb'
+      debian_buster_arm32v7:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'arm32v7/debian_docker'
+        OS_VERSION: 'buster'
+        artifactName: 'Linux-Debian-Buster-ARM'
+        PACKAGE_TO_INSTALL: 'build/*.deb'
+      debian_buster_arm64v8:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'arm64v8/debian_docker'
+        OS_VERSION: 'buster'
+        artifactName: 'Linux-Debian-Buster-ARM64'
+        PACKAGE_TO_INSTALL: 'build/*.deb'
+  pool:
+    vmImage: $(imageName)
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Get libiio artifacts'
+    inputs:
+      source: 'specific'
+      project: '$(System.TeamProjectId)'
+      pipeline: $(libiioPipelineId)
+      artifact: '$(artifactName)'
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      path: '$(Agent.BuildDirectory)/s/build/'
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Get libad9361-iio artifacts'
+    inputs:
+      source: 'specific'
+      project: '$(System.TeamProjectId)'
+      pipeline: $(libad9361iioPipelineId)
+      artifact: '$(artifactName)'
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      path: '$(Agent.BuildDirectory)/s/build/'
+  - script: ./CI/travis/before_install_linux
+    displayName: "Install Dependencies"
+  - script: ./CI/travis/make_linux
+    displayName: "Build"
+
+- job: macOSBuilds
+  strategy:
+    matrix:
+      macOS_10_15:
+        imageName: 'macOS-10.15'
+        artifactName: 'macOS-10.15'
+  pool:
+    vmImage: $(imageName)
+  variables:
+    PACKAGE_TO_INSTALL: 'build/*.pkg'
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Get libiio artifacts'
+    inputs:
+      source: 'specific'
+      project: '$(System.TeamProjectId)'
+      pipeline: $(libiioPipelineId)
+      artifact: '$(artifactName)'
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      path: '$(Agent.BuildDirectory)/s/build/'
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Get libad9361-iio artifacts'
+    inputs:
+      source: 'specific'
+      project: '$(System.TeamProjectId)'
+      pipeline: $(libad9361iioPipelineId)
+      artifact: '$(artifactName)'
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      path: '$(Agent.BuildDirectory)/s/build/'
+  - script: ./CI/travis/before_install_darwin
+    displayName: "Install Dependencies"
+  - script: ./CI/travis/make_darwin
+    displayName: "Build"


### PR DESCRIPTION
This adds the first integration elements for building osc on Linux and Mac.
Windows builds require a bit more work to port, since we will need to re-visit all the dependencies and use Azure Windows images to build osc somehow.
Previously we were cross-building osc using Linux.

Also, this isn't deploying any artifacts yet.
This will require a bit more cmake work.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>