### PR TITLE
plugins: adrv9009: Fix DDS upper limit bug

### DIFF
--- a/glade/adrv9009.glade
+++ b/glade/adrv9009.glade
@@ -158,7 +158,7 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_sampl_freq_obs">
-    <property name="upper">400</property>
+    <property name="upper">600</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
@@ -174,7 +174,7 @@
     <property name="digits">6</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_sampl_freq_rx">
-    <property name="upper">400</property>
+    <property name="upper">600</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
@@ -190,7 +190,7 @@
     <property name="digits">6</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_sampl_freq_tx">
-    <property name="upper">400</property>
+    <property name="upper">600</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>

--- a/plugins/adrv9009.c
+++ b/plugins/adrv9009.c
@@ -1334,10 +1334,6 @@ static GtkWidget *adrv9009_init(struct osc_plugin *plugin, GtkWidget *notebook, 
 
 	/* Transmit settings */
 
-	GtkWidget *sfreq = GTK_WIDGET(gtk_builder_get_object(builder, "sampling_freq_tx"));
-	GtkAdjustment *sfreq_adj = gtk_spin_button_get_adjustment(GTK_SPIN_BUTTON(sfreq));
-	gtk_adjustment_set_upper(sfreq_adj, 307.20); // are these 3 lines necessary?
-
 	/* Bind the IIO device files to the GUI widgets */
 
 	/* Treat 'ensm_mode_available' separately because it will be shared between devices (when more are avaialable) */


### PR DESCRIPTION
This fixes issue:
DDS upper limit wrong on certain devices #289

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>