### PR TITLE
glade: oscplot.glade: Fix Y{min/max} too small issue

### DIFF
--- a/glade/oscplot.glade
+++ b/glade/oscplot.glade
@@ -529,14 +529,14 @@
     </action-widgets>
   </object>
   <object class="GtkAdjustment" id="adjustmentYmax">
-    <property name="lower">-524287</property>
-    <property name="upper">524287</property>
+    <property name="lower">-2147483648</property>
+    <property name="upper">2147483647</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustmentYmin">
-    <property name="lower">-65536</property>
-    <property name="upper">65535</property>
+    <property name="lower">-2147483648</property>
+    <property name="upper">2147483647</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>


### PR DESCRIPTION
Y{min/max} in time plot are only 16-bit values.
For 24-bit ADCs we need more range.

This fixes issue #274

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>