### PR TITLE
osc: Update sampling frequency of ADC when starting a capture

### DIFF
--- a/osc.c
+++ b/osc.c
@@ -1482,6 +1482,8 @@ static int capture_setup(void)
 			if (timeout > min_timeout)
 				min_timeout = timeout;
 		}
+
+		rx_update_device_sampling_freq(iio_device_get_id(dev), freq);
 	}
 
 	if (ctx)


### PR DESCRIPTION
Plugins signal the oscplot as soon as the sampling frequency is changed (usually the control for the sampling frequency is available in the plugin).
However some ADCs might now have an associated plugin but sampling frequency could be changed by using the 'Debug' plugin or even outside of the application. For this scenario, we can't know instantly that the sampling frequency has changed but an improvement is to read the sampling frequency attribute of the ADC right before starting a capture.

This addresses #303 