### PR TITLE
plugins/spectrum_analyzer: Add the capture device as a dependency

### DIFF
--- a/plugins/spectrum_analyzer.c
+++ b/plugins/spectrum_analyzer.c
@@ -900,7 +900,8 @@ static bool analyzer_identify(const struct osc_plugin *plugin)
 	/* Use the OSC's IIO context just to detect the devices */
 	struct iio_context *osc_ctx = get_context_from_osc();
 
-	return !!iio_context_find_device(osc_ctx, PHY_DEVICE);
+	return !!iio_context_find_device(osc_ctx, PHY_DEVICE) &&
+		!!iio_context_find_device(osc_ctx, CAP_DEVICE);
 }
 
 struct osc_plugin plugin = {


### PR DESCRIPTION
Otherwise this plugin will init and error out later.
In theory this shouldn't matter, but there is a yet to be fixed follow
on bug that we avoid with this fix.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>