### PR TITLE
osc: fix close_plugin() for static plugins

### DIFF
--- a/osc.c
+++ b/osc.c
@@ -834,11 +834,14 @@ static void close_plugins(const char *ini_fn)
 
 static void close_plugin(struct osc_plugin *plugin)
 {
-	plugin_lib_list = g_slist_remove(plugin_lib_list, plugin->handle);
-	dlclose(plugin->handle);
 	plugin_list = g_slist_remove(plugin_list, plugin);
-	if (plugin->dynamically_created)
+	plugin_lib_list = g_slist_remove(plugin_lib_list, plugin->handle);
+	if (plugin->dynamically_created) {
+		dlclose(plugin->handle);
 		g_free(plugin);
+	} else {
+		dlclose(plugin->handle);
+	}
 }
 
 static struct osc_plugin * get_plugin_from_name(const char *name)


### PR DESCRIPTION
The commit 5ab930e ("osc: Close plugin if init() fails") closes a
plugin if it fails to initialize. However, this was only tested in
dynamically created plugins where there were no issues. However, it
crashes on static plugins because we get our plugin address using
`dlsym()`. Thus, we cannot really access our object after we do a
`dlclose()` on the library.

So, for static plugins, we need to ensure that `dlclose()` is the last
thing we do when closing the plugin. For dynamic plugins, as it was
allocated at runtime, we can (and we must) call `dlclose()` before we
`g_free()` the plugin. Obviously, we cannot free the plugin and then try
to use `plugin->handle` to close the library.

Signed-off-by: Nuno Sa <nuno.sa@analog.com>