### PR TITLE
CI/appveyor: Get the compiled dependencies from a Github release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,8 @@ install:
   - appveyor DownloadFile http://files.jrsoftware.org/is/5/innosetup-5.6.1.exe innosetup-5.6.1.exe
   - DISPLAY=:0.0 wine innosetup-5.6.1.exe \/VERYSILENT \/SUPPRESSMSGBOXES
 
-  - 'appveyor DownloadFile "https://ci.appveyor.com/api/projects/analogdevicesinc/iio-osc-mingw/artifacts/iio-osc-i686-build-deps.tar.xz?branch=master&job=Environment: MINGW_VERSION=i686" -FileName iio-osc-i686-build-deps.tar.xz'
-  - 'appveyor DownloadFile "https://ci.appveyor.com/api/projects/analogdevicesinc/iio-osc-mingw/artifacts/iio-osc-x86_64-build-deps.tar.xz?branch=master&job=Environment: MINGW_VERSION=x86_64" -FileName iio-osc-x86_64-build-deps.tar.xz'
-
+  - appveyor DownloadFile https://github.com/analogdevicesinc/iio-osc-mingw/releases/latest/download/iio-osc-i686-build-deps.tar.xz
+  - appveyor DownloadFile https://github.com/analogdevicesinc/iio-osc-mingw/releases/latest/download/iio-osc-x86_64-build-deps.tar.xz
   - tar -xf iio-osc-i686-build-deps.tar.xz
   - tar -xf iio-osc-x86_64-build-deps.tar.xz
 


### PR DESCRIPTION
The artifacts stored in the appveyor build expire after 6 months. Since
the iio-osc-mingw gets rarely modified we're better off downloading the
dependecies from the artifacs section of the latest iio-osc-mingw
release.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>