### PR TITLE
plugins: adrv9002: don't rearm the timer on profile failure

### DIFF
--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -709,10 +709,6 @@ err:
 		gtk_file_chooser_set_filename(chooser, priv->last_profile);
 	else
 		gtk_file_chooser_set_filename(chooser, "(None)");
-
-	/* re-arm the timer */
-	priv->refresh_timeout = g_timeout_add(1000, (GSourceFunc)update_display,
-					      priv);
 }
 
 static void adrv9002_combo_box_init(struct adrv9002_combo_box *combo, const char *w_str,


### PR DESCRIPTION
Do not rearm the timer in case the profile fails to load. The plugin was
getting unresponsive in this situation. Moreover, it does not really make
sense to anything on the device if the profiles failed to load. Our only
choice is to try to load the profile again (or some other profile).

Signed-off-by: Nuno Sá <nuno.sa@analog.com>