### PR TITLE
plugins/fmcomms11: Add support for the moved NCO frequency channel

### DIFF
--- a/plugins/fmcomms11.c
+++ b/plugins/fmcomms11.c
@@ -293,7 +293,10 @@ static GtkWidget * fmcomms11_init(struct osc_plugin *plugin, GtkWidget *notebook
 		tx_sampling_freq = 0;
 	}
 
-	ch0 = iio_device_find_channel(dac, "altvoltage2", true);
+	ch0 = iio_device_find_channel(dac, "altvoltage4", true);
+
+	if (!ch0)
+		ch0 = iio_device_find_channel(dac, "altvoltage2", true);
 
 	iio_spin_button_int_init_from_builder(&tx_widgets[num_tx++],
 		dac, ch0, "frequency_nco", builder,


### PR DESCRIPTION
This is required for the kernel driver change:
https://github.com/analogdevicesinc/linux/pull/1522


Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>