### PR TITLE
plugins: adrv9002: improve ORx handling

### DIFF
--- a/glade/adrv9002.glade
+++ b/glade/adrv9002.glade
@@ -1760,6 +1760,7 @@
                                                             <property name="can_focus">True</property>
                                                             <property name="receives_default">False</property>
                                                             <property name="xalign">0</property>
+                                                            <property name="active">True</property>
                                                             <property name="draw_indicator">True</property>
                                                           </object>
                                                           <packing>
@@ -1889,6 +1890,7 @@
                                                             <property name="can_focus">True</property>
                                                             <property name="receives_default">False</property>
                                                             <property name="xalign">0</property>
+                                                            <property name="active">True</property>
                                                             <property name="draw_indicator">True</property>
                                                           </object>
                                                           <packing>


### PR DESCRIPTION
With the latest changes in the adrv9002 driver, if ORx is enabled, we won't
be able to change any control that might trigger an ensm change in
the RX/TX of the same channel as the enabled ORx. Hence, we control the
widgets sensitivity accordingly...

Special care is needed for tracking calibrations. The thing with tracking
cals is that, due to the way the device driver API/Firmware is designed, we
need to move all 4 ports to calibrated state to change a cal (even if we are
only changing cals in one specific port). Hence, we need to make sure that if
one of the ORxs is enabled, we block all the tracking calibrations controls
in all enabled ports.

Also to note that for things to work properly the glade file had to be
changed so that the ORx powerdown toggle is enabled by default.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>