### PR TITLE
[2019_R2] Fix axi tdd identification

### DIFF
--- a/iio_utils.c
+++ b/iio_utils.c
@@ -44,20 +44,21 @@ static gint iio_dev_cmp_by_name(gconstpointer ptr_a, gconstpointer ptr_b)
  */
 GArray * get_iio_devices_starting_with(struct iio_context *ctx, const char *sequence)
 {
-        GArray *devices = g_array_new(FALSE, FALSE, sizeof(struct iio_devices *));
-        size_t i = 0;
+	GArray *devices = g_array_new(FALSE, FALSE, sizeof(struct iio_devices *));
+	size_t i = 0;
 
-        for (; i < iio_context_get_devices_count(ctx); i++) {
-                struct iio_device *dev = iio_context_get_device(ctx, i);
-                const char *dev_name = iio_device_get_name(dev);
-                if (dev_name && !strncmp(sequence, dev_name, strlen(sequence))) {
-                        g_array_append_val(devices, dev);
-                }
-        }
+	for (; i < iio_context_get_devices_count(ctx); i++) {
+		struct iio_device *dev = iio_context_get_device(ctx, i);
+		const char *dev_name = iio_device_get_name(dev);
 
-        g_array_sort(devices, iio_dev_cmp_by_name);
+		if (dev_name && !strncmp(sequence, dev_name, strlen(sequence))) {
+			g_array_append_val(devices, dev);
+		}
+	}
 
-        return devices;
+	g_array_sort(devices, iio_dev_cmp_by_name);
+
+	return devices;
 }
 /*
  * Gets all channels of the specified device sorted in a natural order.

--- a/iio_utils.h
+++ b/iio_utils.h
@@ -23,4 +23,5 @@ int str_natural_cmp(const char *s1, const char *s2);
 
 void handle_toggle_section_cb(GtkToggleToolButton *btn, GtkWidget *section);
 
+char *iio_get_device_label(const struct iio_device *dev);
 #endif  /* __IIO_UTILS__ */

--- a/plugins/cf_axi_tdd.c
+++ b/plugins/cf_axi_tdd.c
@@ -254,16 +254,22 @@ GArray* get_data_for_possible_plugin_instances(void)
 	GArray *data = g_array_new(FALSE, TRUE, sizeof(struct osc_plugin_context *));
 	struct iio_context *osc_ctx = get_context_from_osc();
 	GArray *devices = get_iio_devices_starting_with(osc_ctx, TDD_DEVICE);
-	guint i = 0;
+	guint i = devices->len;
 
-	for (; i < devices->len; i++) {
+	/*
+	 * Let's go backwards as devices are sorted in descending order and we want
+	 * devices to pop up in the tabs in ascending order. We also need to make sure
+	 * to set the name right so that we are actually controlling the right instance
+	 * of the dev.
+	 */
+	while (i-- > 0) {
 		struct osc_plugin_context *context = g_new0(struct osc_plugin_context, 1);
 		struct iio_device *dev = g_array_index(devices, struct iio_device*, i);
 		/* Construct the name of the plugin */
 		char *name;
 
 		if (devices->len > 1)
-			name = g_strdup_printf("%s-%i", THIS_DRIVER, i);
+			name = g_strdup_printf("%s-%i", THIS_DRIVER, devices->len - i);
 		else
 			name = g_strdup(THIS_DRIVER);
 


### PR DESCRIPTION
This is analogous to #323 . However in the 2019_R2 we need to handle IIO labels without direct support from libiio.
In the process, I found out an issue between plugins names and the devices that they are controlling (for dynamically created plugins; the commit message has more details). I included the patch on this PR so that the plugin is functional. However other plugins might also have the same problem. I will have to check and run some tests and potentially open a new PR to address the those.