### PR TITLE
Misc fixes and improvements

### DIFF
--- a/iio_utils.c
+++ b/iio_utils.c
@@ -25,12 +25,19 @@ static gint iio_dev_cmp_by_name(gconstpointer ptr_a, gconstpointer ptr_b)
 {
 	const struct iio_device *dev_a = *(struct iio_device **)ptr_a;
 	const struct iio_device *dev_b = *(struct iio_device **)ptr_b;
+	const char *name_a;
+	const char *name_b;
 
 	g_return_val_if_fail(dev_a, 0);
 	g_return_val_if_fail(dev_b, 0);
 
-	const char *name_a = iio_device_get_name(dev_a);
-	const char *name_b = iio_device_get_name(dev_b);
+	name_a = iio_device_get_label(dev_a);
+	if (!name_a)
+		name_a = iio_device_get_name(dev_a);
+
+	name_b = iio_device_get_label(dev_b);
+	if (!name_b)
+		name_b = iio_device_get_name(dev_b);
 
 	g_return_val_if_fail(name_a, 0);
 	g_return_val_if_fail(name_b, 0);

--- a/osc.h
+++ b/osc.h
@@ -164,6 +164,7 @@ int osc_plugin_default_handle(struct iio_context *ctx,
 		int line, const char *attrib, const char *value,
 		int (*driver_handle)(struct osc_plugin *plugin, const char *, const char *),
 		struct osc_plugin *plugin);
+GArray* get_data_for_possible_plugin_instances_helper(const char *dev_id, const char *plugin);
 
 /* Private functions */
 extern int load_default_profile(char *filename, bool load_plugins);

--- a/plugins/ad9081.c
+++ b/plugins/ad9081.c
@@ -714,43 +714,7 @@ struct osc_plugin *create_plugin(struct osc_plugin_context *plugin_ctx)
 	return plugin;
 }
 
-int iio_device_cmp_by_name(gconstpointer a, gconstpointer b)
-{
-	const char *str_a = iio_device_get_name(*(struct iio_device **)a);
-	const char *str_b = iio_device_get_name(*(struct iio_device **)b);
-
-	return g_strcmp0(str_a, str_b);
-}
-
 GArray* get_data_for_possible_plugin_instances(void)
 {
-	GArray *data = g_array_new(FALSE, TRUE,
-				   sizeof(struct osc_plugin_context *));
-	struct iio_context *osc_ctx = get_context_from_osc();
-	GArray *devices = get_iio_devices_starting_with(osc_ctx, AD9081);
-	guint i = 0;
-
-	g_array_sort(devices, iio_device_cmp_by_name);
-
-	for (; i < devices->len; i++) {
-		struct osc_plugin_context *context = g_new0(struct osc_plugin_context, 1);
-		struct iio_device *dev = g_array_index(devices,
-						       struct iio_device*, i);
-		/* Construct the name of the plugin */
-		char *name;
-
-		if (devices->len > 1)
-			name = g_strdup_printf("%s-%i", THIS_DRIVER, i);
-		else
-			name = g_strdup(THIS_DRIVER);
-
-		context->required_devices = g_list_append(context->required_devices,
-							  g_strdup(iio_device_get_name(dev)));
-		context->plugin_name = name;
-		g_array_append_val(data, context);
-	}
-
-	g_array_free(devices, FALSE);
-
-	return data;
+	return get_data_for_possible_plugin_instances_helper(AD9081, THIS_DRIVER);
 }

--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -1777,43 +1777,7 @@ struct osc_plugin *create_plugin(struct osc_plugin_context *plugin_ctx)
 	return plugin;
 }
 
-int iio_device_cmp_by_name(gconstpointer a, gconstpointer b)
-{
-	const char *str_a = iio_device_get_name(*(struct iio_device **)a);
-	const char *str_b = iio_device_get_name(*(struct iio_device **)b);
-
-	return g_strcmp0(str_a, str_b);
-}
-
 GArray* get_data_for_possible_plugin_instances(void)
 {
-	GArray *data = g_array_new(FALSE, TRUE,
-				   sizeof(struct osc_plugin_context *));
-	struct iio_context *osc_ctx = get_context_from_osc();
-	GArray *devices = get_iio_devices_starting_with(osc_ctx, PHY_DEVICE);
-	guint i = 0;
-
-	g_array_sort(devices, iio_device_cmp_by_name);
-
-	for (; i < devices->len; i++) {
-		struct osc_plugin_context *context = g_new0(struct osc_plugin_context, 1);
-		struct iio_device *dev = g_array_index(devices,
-						       struct iio_device*, i);
-		/* Construct the name of the plugin */
-		char *name;
-
-		if (devices->len > 1)
-			name = g_strdup_printf("%s-%i", THIS_DRIVER, i);
-		else
-			name = g_strdup(THIS_DRIVER);
-
-		context->required_devices = g_list_append(context->required_devices,
-							  g_strdup(iio_device_get_name(dev)));
-		context->plugin_name = name;
-		g_array_append_val(data, context);
-	}
-
-	g_array_free(devices, FALSE);
-
-	return data;
+	return get_data_for_possible_plugin_instances_helper(PHY_DEVICE, THIS_DRIVER);
 }

--- a/plugins/adrv9009_adv.c
+++ b/plugins/adrv9009_adv.c
@@ -1192,29 +1192,5 @@ struct osc_plugin * create_plugin(struct osc_plugin_context *plugin_ctx)
 /* Informs how many plugins can be instantiated and gives context for each possible plugin instance */
 GArray* get_data_for_possible_plugin_instances(void)
 {
-	GArray *data = g_array_new(FALSE, TRUE, sizeof(struct osc_plugin_context *));
-	struct iio_context *osc_ctx = get_context_from_osc();
-	GArray *devices = get_iio_devices_starting_with(osc_ctx, PHY_DEVICE);
-	guint i = 0;
-
-	for (; i < devices->len; i++) {
-		struct osc_plugin_context *context = g_new(struct osc_plugin_context, 1);
-		struct iio_device *dev = g_array_index(devices, struct iio_device*, i);
-
-		/* Construct the name of the plugin */
-		char *name;
-		if (devices->len > 1)
-			name = g_strdup_printf("%s-%i", THIS_DRIVER, i);
-		else
-			name = g_strdup(THIS_DRIVER);
-
-		context->required_devices = NULL;
-		context->required_devices = g_list_append(context->required_devices, g_strdup(iio_device_get_name(dev)));
-		context->plugin_name = name;
-		g_array_append_val(data, context);
-	}
-
-	g_array_free(devices, FALSE);
-
-	return data;
+	return get_data_for_possible_plugin_instances_helper(PHY_DEVICE, THIS_DRIVER);
 }

--- a/plugins/cf_axi_tdd.c
+++ b/plugins/cf_axi_tdd.c
@@ -251,35 +251,5 @@ struct osc_plugin *create_plugin(struct osc_plugin_context *plugin_ctx)
 
 GArray* get_data_for_possible_plugin_instances(void)
 {
-	GArray *data = g_array_new(FALSE, TRUE, sizeof(struct osc_plugin_context *));
-	struct iio_context *osc_ctx = get_context_from_osc();
-	GArray *devices = get_iio_devices_starting_with(osc_ctx, TDD_DEVICE);
-	guint i = 0;
-
-	for (; i < devices->len; i++) {
-		struct osc_plugin_context *context = g_new0(struct osc_plugin_context, 1);
-		struct iio_device *dev = g_array_index(devices, struct iio_device*, i);
-		/* Construct the name of the plugin */
-		char *name;
-		const char *id;
-
-		if (devices->len > 1)
-			name = g_strdup_printf("%s-%i", THIS_DRIVER, i + 1);
-		else
-			name = g_strdup(THIS_DRIVER);
-
-		id = iio_device_get_label(dev);
-		/* fallback to the name */
-		if (!id)
-			id = iio_device_get_name(dev);
-
-		context->required_devices = g_list_append(context->required_devices,
-							  g_strdup(id));
-		context->plugin_name = name;
-		g_array_append_val(data, context);
-	}
-
-	g_array_free(devices, FALSE);
-
-	return data;
+	return get_data_for_possible_plugin_instances_helper(TDD_DEVICE, THIS_DRIVER);
 }


### PR DESCRIPTION
This PR is result of the issues spotted in #340 . The first patch makes the string compare function (used for sorting devices) aware of IIO labels. The rest of the series is  handling the dynamic plugin name creation issue. This is done by introducing a new helper in osc to handle `get_data_for_possible_plugin_instances()`. As a bonus, we remove duplicated code used in all plugins supporting dynamic creation.

Also to note that adrv9002 and ad9081 were not affected by the plugin name issue because they were re-sorting the list of devices returned by `get_iio_devices_starting_with()`. With the new helper, there's no need for that anymore.