### PR TITLE
add iio label support for adrv9002 

### DIFF
--- a/dialogs.c
+++ b/dialogs.c
@@ -24,6 +24,7 @@
 #include "osc.h"
 #include "config.h"
 #include "phone_home.h"
+#include "iio_utils.h"
 
 #ifndef GIT_VERSION
 #define GIT_VERSION	""
@@ -699,7 +700,7 @@ static bool connect_fillin(Dialogs *data)
 		for (i = 0; i < n_devs; i++) {
 			struct iio_device *dev = iio_context_get_device(ctx, i);
 
-			snprintf(text, sizeof(text), "%s\n", iio_device_get_name(dev));
+			snprintf(text, sizeof(text), "%s\n", get_iio_device_label_or_name(dev));
 			gtk_text_buffer_insert(buf, &iter, text, -1);
 		}
 	}

--- a/iio_utils.c
+++ b/iio_utils.c
@@ -31,13 +31,8 @@ static gint iio_dev_cmp_by_name(gconstpointer ptr_a, gconstpointer ptr_b)
 	g_return_val_if_fail(dev_a, 0);
 	g_return_val_if_fail(dev_b, 0);
 
-	name_a = iio_device_get_label(dev_a);
-	if (!name_a)
-		name_a = iio_device_get_name(dev_a);
-
-	name_b = iio_device_get_label(dev_b);
-	if (!name_b)
-		name_b = iio_device_get_name(dev_b);
+	name_a = get_iio_device_label_or_name(dev_a);
+	name_b = get_iio_device_label_or_name(dev_b);
 
 	g_return_val_if_fail(name_a, 0);
 	g_return_val_if_fail(name_b, 0);
@@ -56,11 +51,9 @@ GArray * get_iio_devices_starting_with(struct iio_context *ctx, const char *sequ
 
 	for (; i < iio_context_get_devices_count(ctx); i++) {
 		struct iio_device *dev = iio_context_get_device(ctx, i);
-		const char *dev_name = iio_device_get_name(dev);
-		const char *label = iio_device_get_label(dev);
+		const char *dev_id = get_iio_device_label_or_name(dev);
 
-		if ((label && !strncmp(sequence, label, strlen(sequence))) ||
-		    (dev_name && !strncmp(sequence, dev_name, strlen(sequence)))) {
+		if (dev_id && !strncmp(sequence, dev_id, strlen(sequence))) {
 			g_array_append_val(devices, dev);
 		}
 	}

--- a/iio_utils.c
+++ b/iio_utils.c
@@ -147,3 +147,14 @@ void handle_toggle_section_cb(GtkToggleToolButton *btn, GtkWidget *section)
 			gtk_window_resize(GTK_WINDOW(toplevel), 1, 1);
 	}
 }
+
+const char *get_iio_device_label_or_name(const struct iio_device *dev)
+{
+	const char *id;
+
+	id = iio_device_get_label(dev);
+	if (id)
+		return id;
+
+	return iio_device_get_name(dev);
+}

--- a/iio_utils.h
+++ b/iio_utils.h
@@ -23,4 +23,6 @@ int str_natural_cmp(const char *s1, const char *s2);
 
 void handle_toggle_section_cb(GtkToggleToolButton *btn, GtkWidget *section);
 
+const char *get_iio_device_label_or_name(const struct iio_device *dev);
+
 #endif  /* __IIO_UTILS__ */

--- a/osc.c
+++ b/osc.c
@@ -2927,10 +2927,7 @@ GArray* get_data_for_possible_plugin_instances_helper(const char *dev_id, const 
 		else
 			full_name = g_strdup(plugin);
 
-		id = iio_device_get_label(dev);
-		/* fallback to the name */
-		if (!id)
-			id = iio_device_get_name(dev);
+		id = get_iio_device_label_or_name(dev);
 
 		context->required_devices = g_list_append(context->required_devices, g_strdup(id));
 		context->plugin_name = full_name;

--- a/plugins/debug.c
+++ b/plugins/debug.c
@@ -1430,7 +1430,8 @@ static void debug_register_section_init(struct iio_device *iio_dev)
 
 	if (iio_device_get_debug_attrs_count(dev) > 0) {
 		if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(toggle_detailed_regmap))) {
-			device_xml_file_selection(iio_device_get_name(iio_dev), xml_filename);
+			device_xml_file_selection(get_iio_device_label_or_name(iio_dev),
+						  xml_filename);
 			if (xml_filename[0])
 				device_xml_file_load(xml_filename);
 		}
@@ -1633,7 +1634,7 @@ static GtkWidget * debug_init(struct osc_plugin *plugin, GtkWidget *notebook, co
 
 	for (i = 0; i < nb_devs; i++) {
 		struct iio_device *dev = iio_context_get_device(ctx, i);
-		const gchar *dev_name = iio_device_get_name(dev);
+		const gchar *dev_name = get_iio_device_label_or_name(dev);
 		if (!dev_name)
 			continue;
 		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combobox_device_list), dev_name);


### PR DESCRIPTION
This adds support for IIO labels where needed for the adrv9002 eval boards. I first though I would grep for `iio_device_get_name()` and replace with the new helper introduced here but then I saw that maybe we do not need it in all places. Hence, let's introduce IIO labels "on demand".

Note that this will probably have to syn with #344 