### PR TITLE
[2019_R2] plugins: adrv9002: fix profile configuration on windows

### DIFF
--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -611,7 +611,7 @@ static char *read_file(const char *file, ssize_t *f_size)
 	char *buf;
 	ssize_t size;
 
-	f = fopen(file, "r");
+	f = fopen(file, "rb");
 	if (!f)
 		return NULL;
 


### PR DESCRIPTION
We need to add the binary mode to 'fopen()' as it seems that windows treats
text files and binary files differently (on POSIX systems the b mode is
actually ignored). Otherwise, 'fread()' will actually return less bytes
than asked (with the size computed with fseek + ftell) and we will error
out before loading the stream. This fixes it and causes 'fread' to
return the expected number of bytes.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>