### PR TITLE
plugins: adrv9002: support RX BBDC Loop gain

### DIFF
--- a/glade/adrv9002.glade
+++ b/glade/adrv9002.glade
@@ -12,6 +12,16 @@
     <property name="step_increment">0.050000000000000003</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment_bbdc_loop_gain_rx1">
+    <property name="upper">1.99999999953</property>
+    <property name="step_increment">0.0001</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_bbdc_loop_gain_rx2">
+    <property name="lower">-41.950000000000003</property>
+    <property name="step_increment">0.050000000000000003</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment_gain_orx1">
     <property name="lower">4</property>
     <property name="upper">36</property>
@@ -393,12 +403,6 @@
                                                         <property name="n_columns">4</property>
                                                         <property name="column_spacing">5</property>
                                                         <property name="row_spacing">5</property>
-                                                        <child>
-                                                          <placeholder/>
-                                                        </child>
-                                                        <child>
-                                                          <placeholder/>
-                                                        </child>
                                                         <child>
                                                           <placeholder/>
                                                         </child>
@@ -983,6 +987,44 @@
                                                             <property name="bottom_attach">5</property>
                                                           </packing>
                                                         </child>
+                                                        <child>
+                                                          <object class="GtkLabel" id="label68">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">False</property>
+                                                            <property name="xalign">0.93000000715255737</property>
+                                                            <property name="yalign">0.38999998569488525</property>
+                                                            <property name="label" translatable="yes">BBDC Loop Gain (dB):</property>
+                                                          </object>
+                                                          <packing>
+                                                            <property name="left_attach">2</property>
+                                                            <property name="right_attach">3</property>
+                                                            <property name="top_attach">4</property>
+                                                            <property name="bottom_attach">5</property>
+                                                            <property name="x_options">GTK_FILL</property>
+                                                            <property name="y_options">GTK_FILL</property>
+                                                          </packing>
+                                                        </child>
+                                                        <child>
+                                                          <object class="GtkSpinButton" id="bbdc_loopgain_rx1">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">True</property>
+                                                            <property name="invisible_char">●</property>
+                                                            <property name="primary_icon_activatable">False</property>
+                                                            <property name="secondary_icon_activatable">False</property>
+                                                            <property name="primary_icon_sensitive">True</property>
+                                                            <property name="secondary_icon_sensitive">True</property>
+                                                            <property name="adjustment">adjustment_bbdc_loop_gain_rx1</property>
+                                                            <property name="digits">15</property>
+                                                          </object>
+                                                          <packing>
+                                                            <property name="left_attach">3</property>
+                                                            <property name="right_attach">4</property>
+                                                            <property name="top_attach">4</property>
+                                                            <property name="bottom_attach">5</property>
+                                                            <property name="x_options">GTK_FILL</property>
+                                                            <property name="y_options">GTK_FILL</property>
+                                                          </packing>
+                                                        </child>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -1021,12 +1063,6 @@
                                                         <property name="n_columns">4</property>
                                                         <property name="column_spacing">5</property>
                                                         <property name="row_spacing">5</property>
-                                                        <child>
-                                                          <placeholder/>
-                                                        </child>
-                                                        <child>
-                                                          <placeholder/>
-                                                        </child>
                                                         <child>
                                                           <placeholder/>
                                                         </child>
@@ -1611,6 +1647,43 @@
                                                             <property name="right_attach">2</property>
                                                             <property name="top_attach">4</property>
                                                             <property name="bottom_attach">5</property>
+                                                          </packing>
+                                                        </child>
+                                                        <child>
+                                                          <object class="GtkLabel" id="label69">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">False</property>
+                                                            <property name="xalign">1</property>
+                                                            <property name="label" translatable="yes">BBDC Loop Gain (dB):</property>
+                                                          </object>
+                                                          <packing>
+                                                            <property name="left_attach">2</property>
+                                                            <property name="right_attach">3</property>
+                                                            <property name="top_attach">4</property>
+                                                            <property name="bottom_attach">5</property>
+                                                            <property name="x_options">GTK_FILL</property>
+                                                            <property name="y_options">GTK_FILL</property>
+                                                          </packing>
+                                                        </child>
+                                                        <child>
+                                                          <object class="GtkSpinButton" id="bbdc_loopgain_rx2">
+                                                            <property name="visible">True</property>
+                                                            <property name="can_focus">True</property>
+                                                            <property name="invisible_char">●</property>
+                                                            <property name="primary_icon_activatable">False</property>
+                                                            <property name="secondary_icon_activatable">False</property>
+                                                            <property name="primary_icon_sensitive">True</property>
+                                                            <property name="secondary_icon_sensitive">True</property>
+                                                            <property name="adjustment">adjustment_bbdc_loop_gain_rx2</property>
+                                                            <property name="digits">15</property>
+                                                          </object>
+                                                          <packing>
+                                                            <property name="left_attach">3</property>
+                                                            <property name="right_attach">4</property>
+                                                            <property name="top_attach">4</property>
+                                                            <property name="bottom_attach">5</property>
+                                                            <property name="x_options">GTK_FILL</property>
+                                                            <property name="y_options">GTK_FILL</property>
                                                           </packing>
                                                         </child>
                                                       </object>

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -74,6 +74,7 @@ foreach(plugin ${PLUGINS})
 		${LIBAD9361_LIBRARIES}
 		${EXTRA_WIN_LIBRARIES}
 		osc
+		m
 	)
 
 	set_target_properties(${plugin} PROPERTIES


### PR DESCRIPTION
Add support for manipulating the BBDC loop gain. Since the 'round()'
function is being used in plugin, we need to also explicitly link against
-lm and not rely in some indirect linking.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>