### PR TITLE
plugins: adrv9002: fix digital interface gain report

### DIFF
--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -687,7 +687,7 @@ static void update_special_rx_widgets(struct adrv9002_rx *rx, const int n_widget
 		update_label(&rx[i].decimated_power);
 		update_special_widgets(&rx[i].rx);
 
-		if (digital_gain && strstr(digital_gain, "automatic_control"))
+		if (digital_gain && strstr(digital_gain, "automatic"))
 			combo_box_manual_update(&rx[i].intf_gain);
 nex_widget:
 		g_free(digital_gain);


### PR DESCRIPTION
When the RX digital gain is set to automatic, the plugin was failing to
automatically update the gain. The reason is that the string to indicate
that the gain is automatic changed in the kernel driver from
automatic_control to automatic. This happened when moving to a newer API
version when it became clear that the digital gain ABI was being wrongly
"exported" by the driver and had to be fixed [1].

[1]: https://github.com/analogdevicesinc/linux/commit/63af6a270bb2b361cc5e0c152794a77614b34055
Signed-off-by: Nuno Sá <nuno.sa@analog.com>