### PR TITLE
plugins: cn0511: remove dac frequency set

### DIFF
--- a/plugins/cn0511.c
+++ b/plugins/cn0511.c
@@ -151,11 +151,6 @@ static GtkWidget *cn0511_init(struct osc_plugin *plugin, GtkWidget *notebook,
 		fprintf(stderr, "Failed to enable FIR85. Error: %d\n", ret);
 	}
 
-	ret = iio_device_attr_write_longlong(dac, "sampling_frequency", 6000000000);
-	if (ret < 0) {
-		fprintf(stderr, "Failed to set sampling frequency. Error: %d\n", ret);
-	}
-
 	iio_toggle_button_init_from_builder(&iio_widgets[num_widgets++],
 					    dac_amp, NULL, "en", builder,
 					    "dac_amplifier_enable", 0);


### PR DESCRIPTION
Do not force setting the dac frequency to 6GHz.

The frequency is set now to 6GHz at power-up with:
https://github.com/analogdevicesinc/linux/pull/1941

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>