### PR TITLE
glade/dmm: Reconstruct UI file with Glade 3.38.2

### DIFF
--- a/glade/dmm.glade
+++ b/glade/dmm.glade
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.24"/>
   <object class="GtkListStore" id="channel_list">
     <columns>
       <!-- column-name name -->
@@ -23,51 +24,54 @@
       <column type="gboolean"/>
     </columns>
   </object>
-  <object class="GtkHBox" id="dmm_panel">
+  <object class="GtkBox" id="dmm_panel">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+    <property name="can-focus">False</property>
     <property name="spacing">5</property>
     <child>
-      <object class="GtkVBox" id="box5">
-        <property name="width_request">250</property>
+      <object class="GtkBox" id="box5">
+        <property name="width-request">250</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkFrame" id="frame2">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
-            <property name="shadow_type">none</property>
+            <property name="can-focus">False</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">none</property>
             <child>
               <object class="GtkAlignment" id="alignment2">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+                <property name="can-focus">False</property>
+                <property name="left-padding">12</property>
                 <child>
-                  <object class="GtkVBox" id="input_device_channels">
+                  <object class="GtkBox" id="input_device_channels">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkVBox" id="input_device_channels2">
+                      <object class="GtkBox" id="input_device_channels2">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkScrolledWindow" id="scrolledwindow2">
-                            <property name="height_request">150</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="shadow_type">in</property>
+                            <property name="can-focus">True</property>
+                            <property name="shadow-type">in</property>
+                            <property name="propagate-natural-width">True</property>
+                            <property name="propagate-natural-height">True</property>
                             <child>
                               <object class="GtkTreeView" id="device_list_view">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="model">device_list</property>
-                                <property name="headers_visible">False</property>
-                                <property name="headers_clickable">False</property>
-                                <property name="search_column">0</property>
+                                <property name="headers-visible">False</property>
+                                <property name="headers-clickable">False</property>
+                                <property name="search-column">0</property>
                                 <child internal-child="selection">
-                                  <object class="GtkTreeSelection" id="treeview-selection1"/>
+                                  <object class="GtkTreeSelection"/>
                                 </child>
                                 <child>
                                   <object class="GtkTreeViewColumn" id="treeviewcolumn3">
@@ -102,8 +106,8 @@
                         </child>
                       </object>
                       <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
@@ -112,14 +116,11 @@
               </object>
             </child>
             <child type="label">
-              <object class="GtkLabel" id="label4">
+              <object class="GtkLabel" id="label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Device</property>
-                <property name="use_markup">True</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;Device&lt;/b&gt;</property>
+                <property name="use-markup">True</property>
               </object>
             </child>
           </object>
@@ -132,52 +133,53 @@
         <child>
           <object class="GtkFrame" id="frame10">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
-            <property name="shadow_type">none</property>
+            <property name="can-focus">False</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">none</property>
             <child>
               <object class="GtkAlignment" id="alignment11">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="left_padding">12</property>
+                <property name="can-focus">False</property>
+                <property name="left-padding">12</property>
                 <child>
-                  <object class="GtkVBox" id="input_device_channels1">
+                  <object class="GtkBox" id="input_device_channels1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkButton" id="all_channels">
                         <property name="label" translatable="yes">All Channels</property>
-                        <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
-                        <property name="fill">False</property>
+                        <property name="fill">True</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow" id="scrolledwindow1">
-                        <property name="height_request">150</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="shadow_type">in</property>
+                        <property name="can-focus">True</property>
+                        <property name="shadow-type">in</property>
+                        <property name="propagate-natural-width">True</property>
+                        <property name="propagate-natural-height">True</property>
                         <child>
                           <object class="GtkTreeView" id="channel_list_view">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="can-focus">True</property>
                             <property name="model">channel_list</property>
-                            <property name="headers_visible">False</property>
-                            <property name="headers_clickable">False</property>
-                            <property name="search_column">0</property>
+                            <property name="headers-visible">False</property>
+                            <property name="headers-clickable">False</property>
+                            <property name="search-column">0</property>
                             <child internal-child="selection">
-                              <object class="GtkTreeSelection" id="treeview-selection2"/>
+                              <object class="GtkTreeSelection"/>
                             </child>
                             <child>
                               <object class="GtkTreeViewColumn" id="treeviewcolumn1">
-                                <property name="title" translatable="yes">Active</property>
+                                <property name="title" translatable="yes">column</property>
                                 <child>
                                   <object class="GtkCellRendererToggle" id="channel_toggle"/>
                                   <attributes>
@@ -188,7 +190,7 @@
                             </child>
                             <child>
                               <object class="GtkTreeViewColumn" id="treeviewcolumn2">
-                                <property name="title" translatable="yes">Name</property>
+                                <property name="title" translatable="yes">column</property>
                                 <child>
                                   <object class="GtkCellRendererText" id="cellrenderertext2"/>
                                   <attributes>
@@ -213,12 +215,9 @@
             <child type="label">
               <object class="GtkLabel" id="label14">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Active channels</property>
-                <property name="use_markup">True</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">&lt;b&gt;Active channels&lt;/b&gt;</property>
+                <property name="use-markup">True</property>
               </object>
             </child>
           </object>
@@ -237,30 +236,25 @@
       </packing>
     </child>
     <child>
-      <object class="GtkVBox" id="disp_dmm">
+      <object class="GtkBox" id="disp_dmm">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkHButtonBox" id="buttonbox1">
+          <object class="GtkToolbar" id="gtktoolbar1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">start</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkToggleToolButton" id="dmm_button">
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="has_tooltip">True</property>
-                <property name="tooltip_markup" translatable="yes">Play/Stop</property>
-                <property name="tooltip_text" translatable="yes">Play/Stop</property>
-                <property name="label" translatable="yes">DMM</property>
-                <property name="use_underline">True</property>
-                <property name="stock_id">gtk-media-play</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-markup" translatable="yes">Start/Stop</property>
+                <property name="use-underline">True</property>
+                <property name="icon-name">gtk-media-play</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
+                <property name="homogeneous">True</property>
               </packing>
             </child>
           </object>
@@ -271,16 +265,19 @@
           </packing>
         </child>
         <child>
+          <placeholder/>
+        </child>
+        <child>
           <object class="GtkTextView" id="dmm_results">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can-focus">True</property>
             <property name="editable">False</property>
-            <property name="cursor_visible">False</property>
+            <property name="cursor-visible">False</property>
           </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/osc.c
+++ b/osc.c
@@ -295,8 +295,9 @@ static GtkWidget* plugin_tab_add_detach_btn(GtkWidget *page, const struct detach
 
 	tab_box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 	tab_label = gtk_label_new(plugin_name);
-	// TO DO: handle the line below using GTK3
-	tab_detach_btn = NULL;//(GtkWidget *)gtk_tool_button_new_from_stock("gtk-disconnect");
+	// TO DO: since "gtk-disconnect" is no longer available, maybe use a custom image
+	tab_detach_btn = (GtkWidget *)gtk_tool_button_new(
+		gtk_image_new_from_icon_name("window-new", GTK_ICON_SIZE_SMALL_TOOLBAR), NULL);
 
 	gtk_widget_set_size_request(tab_detach_btn, 25, 25);
 
@@ -417,6 +418,7 @@ static void detach_plugin(GtkToolButton *btn, gpointer data)
 	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 
 	gtk_window_set_title(GTK_WINDOW(window), page_name);
+	gtk_container_remove(GTK_CONTAINER(notebook), page);
 	gtk_container_add(GTK_CONTAINER(hbox), page);
 	gtk_container_add(GTK_CONTAINER(window), hbox);
 


### PR DESCRIPTION
Rebuild the DMM glade file with Glade 3.38.2.
This will make things easier if one wants to further modify the glade file. Also Glade 3.38.2 is the latest release at the moment and it targets UI files for GTK3 based applications.

Downsides:
 - The "gtk-disconnect" stock icon is no longer available. I have used "window-new" icon instead. Also the icon seems oversized. This icon is used next to the name of each plugin allowing people to detach the plugin into a new window.