### PR TITLE
cmake: Move -rdynamic flag from compiler to linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 	add_compile_options(-mwindows)
 	set(WIN_LINK_FLAGS "-Wl,--export-all-symbols -Wl,--subsystem,windows")
 else()
-	add_compile_options(-rdynamic)
+	add_link_options(-rdynamic)
 endif()
 
 add_library(osc ${OSC_SRC})


### PR DESCRIPTION
This is because rdynamic is a linker flag. And also there are reports that during build warnings(or errors) happend because of this flag being provided to compiler.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>