### PR TITLE
plugins: adrv9002: fix segfault with dac buffering

### DIFF
--- a/plugins/ad9081.c
+++ b/plugins/ad9081.c
@@ -675,10 +675,11 @@ static void context_destroy(struct osc_plugin *plugin, const char *ini_fn)
 {
 	struct plugin_private *priv = plugin->priv;
 
-	osc_plugin_context_free_resources(&priv->plugin_ctx);
-	osc_destroy_context(priv->ctx);
 	if (priv->dac_tx_manager)
 		dac_data_manager_free(priv->dac_tx_manager);
+
+	osc_destroy_context(priv->ctx);
+	osc_plugin_context_free_resources(&priv->plugin_ctx);
 	g_free(priv);
 }
 

--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -1839,14 +1839,14 @@ static void context_destroy(struct osc_plugin *plugin, const char *ini_fn)
 	struct plugin_private *priv = plugin->priv;
 	int i;
 
-	osc_plugin_context_free_resources(&priv->plugin_ctx);
-	osc_destroy_context(priv->ctx);
+	g_source_remove(priv->refresh_timeout);
 
 	for (i = 0; i < priv->n_dacs; i++) {
 		dac_data_manager_free(priv->dac_manager[i].dac_tx_manager);
 	}
 
-	g_source_remove(priv->refresh_timeout);
+	osc_destroy_context(priv->ctx);
+	osc_plugin_context_free_resources(&priv->plugin_ctx);
 	g_free(priv);
 }
 


### PR DESCRIPTION
The DAC Manager holds a weak reference to the IIO context (passed by the plugin) which it uses to handle the dac devices (eg: creating buffers). In dac_data_manager_free(), the Manager will destroy any buffers that were created which means we cannot destroy the IIO context before calling this function...

While at it, reordered how resources are freed during the plugin destructor so that we free things in the reverse order they were created (as it should be typically done).

Signed-off-by: Nuno Sá <nuno.sa@analog.com>