### PR TITLE
cmake: Move -rdynamic flag from compiler to linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 	add_compile_options(-mwindows)
 	set(WIN_LINK_FLAGS "-Wl,--export-all-symbols -Wl,--subsystem,windows")
 else()
-	add_compile_options(-rdynamic)
+	add_link_options(-rdynamic)
 endif()
 
 add_library(osc ${OSC_SRC})


### PR DESCRIPTION
This is because rdynamic is a linker flag. And also there are reports that during build warnings(or errors) happend because of this flag being provided to compiler.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>
(cherry picked from commit ff33ac3b2f2e4f70e14ba0ace8983007825c6158)
Signed-off-by: Nuno Sá <nuno.sa@analog.com>
---

Since this is a fix, it makes sense to have it in (at least) in the next release. Once #409 gets merged, we should also apply it in here.