### PR TITLE
Add Flatpak target and workflow

### DIFF
--- a/.github/workflows/buildflatpak.yml
+++ b/.github/workflows/buildflatpak.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches: [master,flatpak]
+  pull_request:
+name: flatpak build
+jobs:
+  flatpak:
+    name: "Flatpak"
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-40
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v2
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@v5
+      with:
+        bundle: iio-oscilloscope.flatpak
+        manifest-path: CI/flatpak/app.yml
+        cache-key: flatpak-builder-${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ adi-osc.desktop
 org.adi.pkexec.osc.policy
 osc-wrapper
 .vscode
+.flatpak-builder
+CI/flatpak/repo

--- a/CI/flatpak/app.yml
+++ b/CI/flatpak/app.yml
@@ -1,0 +1,59 @@
+app-id: org.adi.IIO-Oscilloscope
+runtime: org.gnome.Platform
+runtime-version: '43'
+command: osc
+sdk: org.gnome.Sdk
+rename-desktop-file: adi-osc.desktop
+rename-icon: adi-osc
+finish-args:
+   - --socket=x11
+   - --socket=wayland
+   - --share=network
+   - --share=ipc
+   - --device=all
+   - --system-talk-name=org.freedesktop.Avahi
+   - --filesystem=xdg-config/org.adi.IIO-Oscilloscope:create
+tags:
+   - devel
+   - development
+   - nightly
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /lib/debug
+  - /lib/girepository-*
+  - /share/pkgconfig
+  - /share/aclocal
+  - /man
+  - /share/man
+  - '*.la'
+  - '*.a'
+  - /share/doc
+modules:
+# -- gtk3 widgets
+  - deps/gtkdatabox.yml
+# -- libaio
+  - deps/libaio.yml
+# -- libiio
+  - deps/libxml2.yml
+  - deps/libusb.yml
+  - deps/intltool.yml
+  - deps/avahi.yml
+  - deps/libiio.yml
+# -- libad*-iio
+  - deps/libad9166-iio.yml
+  - deps/libad9361-iio.yml
+# -- jansson
+  - deps/jansson.yml
+# -- matio
+  - deps/matio.yml
+# -- app
+  - name: osc
+    buildsystem: cmake
+    builddir: true
+    sources:
+      - type: dir
+        path: ../../
+    config-opts:
+      - -D CMAKE_INSTALL_PREFIX=/app

--- a/CI/flatpak/deps/avahi.yml
+++ b/CI/flatpak/deps/avahi.yml
@@ -1,0 +1,18 @@
+name: avahi
+config-opts:
+  - --with-distro=none
+  - --disable-libdaemon
+  - --disable-core-docs
+  - --disable-manpages
+  - --disable-mono
+  - --disable-qt3
+  - --disable-qt4
+  - --disable-python
+  - --disable-gtk
+  - --disable-gtk3
+cleanup:
+  - /lib/avahi
+sources:
+  - type: archive
+    url: https://avahi.org/download/avahi-0.7.tar.gz
+    sha256: 57a99b5dfe7fdae794e3d1ee7a62973a368e91e414bd0dfa5d84434de5b14804

--- a/CI/flatpak/deps/gtkdatabox.yml
+++ b/CI/flatpak/deps/gtkdatabox.yml
@@ -1,0 +1,7 @@
+name: gtkdatabox
+cleanup:
+  - /lib/gtkdatabox-*
+sources:
+  - type: archive
+    url: https://download.sourceforge.net/project/gtkdatabox/gtkdatabox-1/gtkdatabox-1.0.0.tar.gz
+    sha256: 8bee70206494a422ecfec9a88d32d914c50bb7a0c0e8fedc4512f5154aa9d3e3

--- a/CI/flatpak/deps/intltool.yml
+++ b/CI/flatpak/deps/intltool.yml
@@ -1,0 +1,5 @@
+name: intltool
+sources:
+  - type: archive
+    url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+    md5: 12e517cac2b57a0121cda351570f1e63

--- a/CI/flatpak/deps/jansson.yml
+++ b/CI/flatpak/deps/jansson.yml
@@ -1,0 +1,7 @@
+name: jansson
+cleanup:
+  - /lib/jansson-*
+sources:
+  - type: archive
+    url: https://github.com/akheron/jansson/releases/download/v2.14/jansson-2.14.tar.gz
+    sha256: 5798d010e41cf8d76b66236cfb2f2543c8d082181d16bc3085ab49538d4b9929

--- a/CI/flatpak/deps/libad9166-iio.yml
+++ b/CI/flatpak/deps/libad9166-iio.yml
@@ -1,0 +1,8 @@
+name: libad9166-iio
+buildsystem: cmake
+cleanup:
+  - /lib/ad9166-iio-*
+sources:
+  - type: git
+    url: https://github.com/analogdevicesinc/libad9166-iio
+    branch: master

--- a/CI/flatpak/deps/libad9361-iio.yml
+++ b/CI/flatpak/deps/libad9361-iio.yml
@@ -1,0 +1,8 @@
+name: libad9361-iio
+buildsystem: cmake
+cleanup:
+  - /lib/ad9361-iio-*
+sources:
+  - type: git
+    url: https://github.com/analogdevicesinc/libad9361-iio
+    branch: master

--- a/CI/flatpak/deps/libaio.yml
+++ b/CI/flatpak/deps/libaio.yml
@@ -1,0 +1,9 @@
+name: libaio
+buildsystem: simple
+build-commands:
+  - make prefix=$FLATPAK_DEST install
+sources:
+  - type: git
+    url: https://pagure.io/libaio.git
+    tag: libaio-0.3.113
+    commit: 1b18bfafc6a2f7b9fa2c6be77a95afed8b7be448

--- a/CI/flatpak/deps/libiio.yml
+++ b/CI/flatpak/deps/libiio.yml
@@ -1,0 +1,14 @@
+name: libiio
+builddir: true
+buildsystem: cmake
+config-opts:
+  - -DCMAKE_INSTALL_PREFIX:PATH=/app
+  - -DCMAKE_INSTALL_LIBDIR:STRING=lib
+  - -DWITH_TESTS:BOOL=OFF
+  - -DWITH_DOC:BOOL=OFF
+  - -DWITH_IIOD:BOOL=OFF
+  - -DINSTALL_UDEV_RULE:BOOL=OFF
+sources:
+  - type: git
+    url: https://github.com/analogdevicesinc/libiio
+    commit: v0.24

--- a/CI/flatpak/deps/libusb.yml
+++ b/CI/flatpak/deps/libusb.yml
@@ -1,0 +1,9 @@
+name: libusb
+config-opts:
+  - --disable-udev
+  - --prefix=/app
+sources:
+  - type: archive
+    url: https://downloads.sourceforge.net/project/libusb/libusb-1.0/libusb-1.0.26/libusb-1.0.26.tar.bz2
+    sha256: 12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5
+

--- a/CI/flatpak/deps/libxml2.yml
+++ b/CI/flatpak/deps/libxml2.yml
@@ -1,0 +1,7 @@
+name: libxml2
+config-opts:
+  - --without-python
+sources:
+  - type: archive
+    url: https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.9.tar.xz
+    sha256: 58a5c05a2951f8b47656b676ce1017921a29f6b1419c45e3baed0d6435ba03f5

--- a/CI/flatpak/deps/matio.yml
+++ b/CI/flatpak/deps/matio.yml
@@ -1,0 +1,7 @@
+name: matio
+cleanup:
+  - /lib/matio-*
+sources:
+  - type: archive
+    url: https://github.com/tbeu/matio/releases/download/v1.5.23/matio-1.5.23.tar.gz
+    sha256: 9f91eae661df46ea53c311a1b2dcff72051095b023c612d7cbfc09406c9f4d6e

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,8 +256,11 @@ install(TARGETS oscmain RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Set default CMAKE_PREFIX_PATH to CMAKE_SYSTEM_PREFIX_PATH
 set(CMAKE_PREFIX_PATH ${CMAKE_SYSTEM_PREFIX_PATH})
-
-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+# Flatpaks have policies defined in the yml manifest file
+if (${CMAKE_INSTALL_PREFIX} MATCHES "/app")
+set(IS_FLATPAK_CI ON)
+endif()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND NOT(IS_FLATPAK_CI))
 	configure_file(org.adi.pkexec.osc.policy.cmakein ${CMAKE_CURRENT_BINARY_DIR}/org.adi.pkexec.osc.policy @ONLY)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.adi.pkexec.osc.policy
 		DESTINATION ${CMAKE_POLKIT_PREFIX}/${CMAKE_INSTALL_DATADIR}/polkit-1/actions/)


### PR DESCRIPTION
Generate a flatpak package[1], as we already do with Scopy.

Flatpak policy is set in the manifest files instead of through CMake, therefore during flatpak build:
* libiio is compiled with -DINSTALL_UDEV_RULE=OFF.
* CMakeLists.txt  does not install org.adi.pkexec.osc.policy file.

The flatpak build was tested with org.gnome.Platform version x86_64/3.38 (oldest available in flathub) and x86_64/43 (latest).


The [Flathub/Flatpak Builder](https://github.com/marketplace/actions/flatpak-builder) GitHub Action is being used,
which will pull an image from the author's account (gnome developer, flathub maintainer)
(if that's not ok, we can create our own image a publish in Docker hub, like in the others workflows).

[1] The flatpak package is available for master/flatpak branches, at  flatpak build -> Summary -> Artifacts, we could include 
to the Release Assets list.

Suggestions are welcome.