### PR TITLE
Mingw-build: create osc installer using latest iio libs

### DIFF
--- a/.github/workflows/buildmingw.yml
+++ b/.github/workflows/buildmingw.yml
@@ -35,6 +35,9 @@ jobs:
                 -e BRANCH=%GITHUB_REF_NAME% ^
                 -e HEAD_BRANCH=%GITHUB_HEAD_REF% ^
                 -e OSC_BUILD_VER=%TAG% ^
+                -e LIBIIO_BRANCH=v0.24 ^
+                -e LIBAD9361_BRANCH=master ^
+                -e LIBAD9166_BRANCH=master ^
                 shooteu/iio-oscilloscope C:\msys64\usr\bin\bash.exe -c '/home/docker/iio-oscilloscope/CI/docker/inside_docker.sh'
             
     - uses: actions/upload-artifact@v3

--- a/CI/docker/build_mingw.sh
+++ b/CI/docker/build_mingw.sh
@@ -1,8 +1,5 @@
 #/bin/bash
 set -xe
-LIBIIO_BRANCH=master
-LIBAD9361_BRANCH=master
-LIBAD9166_BRANCH=master
 
 export WORKDIR=/home/$USER/
 
@@ -65,8 +62,13 @@ get_innosetup() {
 
 build_libiio() {
 	pushd $WORKDIR
-	git clone https://github.com/analogdevicesinc/libiio --branch $LIBIIO_BRANCH
+	export DIR="$WORKDIR/libiio"
+	if [ -d "$DIR" ]; then
+  		rm -rf $DIR
+	fi
+	git clone https://github.com/analogdevicesinc/libiio
 	cd libiio
+	git checkout $LIBIIO_BRANCH
 	mkdir build
 	cd build
 	$CMAKE $CMAKE_OPTS -G"Unix Makefiles" -DWITH_SERIAL_BACKEND=ON ../
@@ -76,8 +78,13 @@ build_libiio() {
 
 build_libad9361() {
 	pushd $WORKDIR
-	git clone https://github.com/analogdevicesinc/libad9361-iio --branch $LIBAD9361_BRANCH
+	export DIR="$WORKDIR/libad9361-iio"
+	if [ -d "$DIR" ]; then
+  		rm -rf $DIR
+	fi
+	git clone https://github.com/analogdevicesinc/libad9361-iio
 	cd libad9361-iio
+	git checkout $LIBAD9361_BRANCH
 	mkdir build
 	cd build
 	$CMAKE $CMAKE_OPTS -G"Unix Makefiles" ../
@@ -87,8 +94,13 @@ build_libad9361() {
 
 build_libad9166 () {
 	pushd $WORKDIR
-	git clone https://github.com/analogdevicesinc/libad9166-iio --branch $LIBAD9166_BRANCH
+	export DIR="$WORKDIR/libad9166-iio"
+	if [ -d "$DIR" ]; then
+  		rm -rf $DIR
+	fi
+	git clone https://github.com/analogdevicesinc/libad9166-iio
 	cd libad9166-iio
+	git checkout $LIBAD9166_BRANCH
 	mkdir build
 	cd build
 	$CMAKE $CMAKE_OPTS -G"Unix Makefiles" ../

--- a/CI/docker/inside_docker.sh
+++ b/CI/docker/inside_docker.sh
@@ -8,6 +8,18 @@ cd $SRCDIR
 
 sed "s/UNSET_VERSION/${OSC_BUILD_VER}/" osc.iss > updated-osc.iss
 
+# build libiio
+
+./CI/docker/build_mingw.sh build_libiio
+
+# build libad9361
+
+./CI/docker/build_mingw.sh build_libad9361
+
+# build libad9166 
+
+./CI/docker/build_mingw.sh build_libad9166
+
 # build osc
 
 ./CI/docker/build_mingw.sh build_osc


### PR DESCRIPTION
build latest libiio, libad9361, libad9661 inside windows docker 
pass branch/tag/SHA for lib repos as environment variables when running the docker image in workflow file

This allows compiling and bundling the windows installer with the desired versions of libiio, libad9361, libad9661 