### PR TITLE
Remove workaround when checking for a trigger of a device

### DIFF
--- a/osc.c
+++ b/osc.c
@@ -1420,7 +1420,7 @@ static double read_sampling_frequency(const struct iio_device *dev)
 				buf, sizeof(buf));
 	if (ret < 0) {
 		const struct iio_device *trigger;
-		ret = osc_iio_device_get_trigger(dev, &trigger);
+		ret = iio_device_get_trigger(dev, &trigger);
 		if (ret == 0 && trigger) {
 			attr = iio_device_find_attr(trigger, "sampling_frequency");
 			if (!attr)
@@ -1430,6 +1430,10 @@ static double read_sampling_frequency(const struct iio_device *dev)
 					sizeof(buf));
 			else
 				ret = -ENOENT;
+		} else {
+			fprintf(stderr, "Failed to check if device: %s has trigger. Error:"
+				"%s\n", iio_device_get_name(dev) ?: iio_device_get_id(dev),
+				strerror(-ret));
 		}
 	}
 

--- a/osc.h
+++ b/osc.h
@@ -174,26 +174,6 @@ extern void do_init(struct iio_context *new_ctx);
 extern void create_default_plot(void);
 extern GtkWidget * new_plot_cb(GtkMenuItem *item, gpointer user_data);
 extern bool check_inifile(const char *filepath);
-
-/*
- * There is a bug in libiio that lets it return -EIO if no trigger is
- * assigned. Assume that EIO means there is a trigger, but none
- * assigned. Drop since once libiio has been fixed for a while.
- */
-static inline int osc_iio_device_get_trigger(const struct iio_device *dev,
-	const struct iio_device **trigger)
-{
-	int ret;
-
-	ret = iio_device_get_trigger(dev, trigger);
-	if (ret == -EIO) {
-		ret = 0;
-		*trigger = NULL;
-	}
-
-	return ret;
-}
-
 extern int osc_load_glade_file(GtkBuilder *builder, const char *fname);
 extern int osc_load_objects_from_glade_file(GtkBuilder *builder, const char *fname, gchar **object_ids);
 

--- a/oscplot.c
+++ b/oscplot.c
@@ -2195,12 +2195,16 @@ static gboolean check_valid_setup_of_device(OscPlot *plot, const char *name)
 	const struct iio_device *trigger;
 	int ret;
 
-	ret = osc_iio_device_get_trigger(dev, &trigger);
+	ret = iio_device_get_trigger(dev, &trigger);
 	if (ret == 0 && trigger == NULL && num_enabled > 0) {
 		snprintf(warning_text, sizeof(warning_text),
 				"Device %s needs an impulse generator", name);
 		gtk_widget_set_tooltip_text(priv->capture_button, warning_text);
 		return false;
+	} else {
+		fprintf(stderr, "Failed to check if device: %s has trigger. Error:"
+			"%s\n", iio_device_get_name(dev) ?: iio_device_get_id(dev),
+			strerror(-ret));
 	}
 
 	/* Additional validation rules provided by the plugin of the device */
@@ -6767,11 +6771,15 @@ static gboolean right_click_menu_show(OscPlot *plot, GdkEvent *event)
 		bool has_trigger;
 		int ret;
 
-		ret = osc_iio_device_get_trigger(dev, &trigger);
-		if (ret == 0)
+		ret = iio_device_get_trigger(dev, &trigger);
+		has_trigger = false;
+		if (ret == 0 && trigger) {
 			has_trigger = true;
-		else
-			has_trigger = false;
+		} else {
+			fprintf(stderr, "Failed to check if device: %s has trigger. Error:"
+				"%s\n", iio_device_get_name(dev) ?: iio_device_get_id(dev),
+				strerror(-ret));
+		}
 
 		gtk_widget_set_sensitive(priv->device_trigger_menuitem,
 				has_trigger);

--- a/trigger_dialog.c
+++ b/trigger_dialog.c
@@ -92,7 +92,7 @@ static void trigger_load_settings(GtkBuilder *builder, const char *device)
 	if (!dev)
 		return;
 
-	ret = osc_iio_device_get_trigger(dev, &trigger);
+	ret = iio_device_get_trigger(dev, &trigger);
 	if (ret < 0)
 		trigger = NULL;
 


### PR DESCRIPTION
The bug where libiio would return error EIO in case the iio device supports a trigger but none is assigned, no longer exists in latest versions of libiio. Probably was fixed long time ago. However I found that on serial backend the EIO is being returned by iio_device_get_trigger() even though the intention was to report that iio device doesn't support/need a trigger. The expected behaviour is that 0 is returned and trigger argument is set to NULL. But this unhappy coincidence was forcing users to provide a trigger for an iio device that does not need one. It happened that no trigger was available making the users unable to ask for samples from the device. Note: this doesn't happend to all scenarios where serial backend is used. I have seen the issue only on 2 projects. And I have seen it working properly on other projects.