### PR TITLE
plugins: spectrum_analyser: Fix sampling freq check

### DIFF
--- a/plugins/spectrum_analyzer.c
+++ b/plugins/spectrum_analyzer.c
@@ -389,9 +389,8 @@ static bool configure_data_capture(plugin_setup *setup)
 	device_set_rx_sampling_freq(dev, sampling_rate);
 	rate = device_get_rx_sampling_freq(cap);
 	if (rate != sampling_rate) {
-		fprintf(stderr, "Failed to set the rx sampling rate to %lld"
-			"in %s\n", sampling_rate, __func__);
-		return false;
+		fprintf(stderr, "Failed to set the rx sampling rate to %lld "
+			"(actual rate is %lld) in %s\n", sampling_rate, rate, __func__);
 	}
 
 	dev_info = iio_device_get_data(cap);


### PR DESCRIPTION
When trying to start the spectrum analyzer from the plugin, any mismatch between the requested sampling rate and the set rate read back causes the plugin to fail to launch due to a `return false`.

On many systems, there is a small mismatch where `61440000` (default rate) will return `61439999`, causing a match failures. This change simply logs the mistmatch warning, but still allows the output window to be shown.