### PR TITLE
plugins/cn0540: fix segmentation fault

### DIFF
--- a/plugins/cn0540.c
+++ b/plugins/cn0540.c
@@ -348,7 +348,7 @@ static void cn0540_get_channels()
 {
 	gboolean direction = TRUE;
 	int idx = -1;
-	char label[9] = "voltage0";
+	char label[10] = "voltage0";
 
 	adc_ch = iio_device_find_channel(iio_adc, ADC_DEVICE_CH, FALSE);
 	dac_ch = iio_device_find_channel(iio_dac, DAC_DEVICE_CH, TRUE);
@@ -385,6 +385,7 @@ static void cn0540_get_channels()
 			if (label[7] == ':') {
 				label[7] = '1';
 				label[8] = '0';
+				label[9] = 0;
 			}
 		}
 	}


### PR DESCRIPTION
allocate enough space for channel labels with double digits and NULL 
add NULL for channels with double digits

this fixes segmentation fault which appears when running osc on ADI Kuiper Linux on Zynq Cora boards with the CN0540