### PR TITLE
Fix Azure CI

### DIFF
--- a/CI/azure/build_osc_arm.sh
+++ b/CI/azure/build_osc_arm.sh
@@ -23,6 +23,7 @@ install_apt_pkgs() {
         	autotools-dev \
         	autoconf \
         "
+	apt-get update
 	apt-get install -y $APT_PKGS
 	git config --global --add safe.directory /ci
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,7 +129,7 @@ stages:
         pipeline: $(libiioPipelineId)
         artifact: '$(artifactName)'
         runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/main'
+        runBranch: 'refs/heads/libiio-v0'
         path: '$(Agent.BuildDirectory)/s/download/'
       displayName: 'Get libiio artifacts'
     - task: DownloadPipelineArtifact@2
@@ -139,7 +139,7 @@ stages:
         pipeline: $(libad9361iioPipelineId)
         artifact: '$(artifactName)'
         runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/master'
+        runBranch: 'refs/heads/libad9361-iio-v0'
         path: '$(Agent.BuildDirectory)/s/download/'
       displayName: 'Get libad9361-iio artifacts'
     - task: DownloadPipelineArtifact@2
@@ -149,7 +149,7 @@ stages:
         pipeline: $(libad9166iioPipelineId)
         artifact: '$(artifactName)'
         runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/master'
+        runBranch: 'refs/heads/libad9166-iio-v0'
         path: '$(Agent.BuildDirectory)/s/download/'
       displayName: 'Get libad9166-iio artifacts'
     - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,6 @@ trigger:
     - master
     - staging/*
     - 20*
-    - fix-azure-ci
   tags:
     include:
     - v*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ trigger:
     - master
     - staging/*
     - 20*
+    - fix-azure-ci
   tags:
     include:
     - v*
@@ -56,7 +57,7 @@ stages:
         pipeline: $(libiioPipelineId)
         artifact: '$(artifactName)'
         runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/master'
+        runBranch: 'refs/heads/libiio-v0'
         path: '$(Agent.BuildDirectory)/s/download/'
       displayName: 'Get libiio artifacts'
     - task: DownloadPipelineArtifact@2
@@ -66,7 +67,7 @@ stages:
         pipeline: $(libad9361iioPipelineId)
         artifact: '$(artifactName)'
         runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/master'
+        runBranch: 'refs/heads/libad9361-iio-v0'
         path: '$(Agent.BuildDirectory)/s/download/'
       displayName: 'Get libad9361-iio artifacts'
     - task: DownloadPipelineArtifact@2
@@ -76,7 +77,7 @@ stages:
         pipeline: $(libad9166iioPipelineId)
         artifact: '$(artifactName)'
         runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/master'
+        runBranch: 'refs/heads/libad9166-iio-v0'
         path: '$(Agent.BuildDirectory)/s/download/'
       displayName: 'Get libad9166-iio artifacts'
     - script: |
@@ -128,7 +129,7 @@ stages:
         pipeline: $(libiioPipelineId)
         artifact: '$(artifactName)'
         runVersion: 'latestFromBranch'
-        runBranch: 'refs/heads/master'
+        runBranch: 'refs/heads/main'
         path: '$(Agent.BuildDirectory)/s/download/'
       displayName: 'Get libiio artifacts'
     - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
- azure-pipelines will now pull the libiio, libad9361, libad9166 artifacts corresponding to the libiio-v0 API 
this will ensure that the CI will work for the current version of osc, until moving to libiio-v1

- added apt-get update to build_osc_arm script to prevent E: Failed to fetch package name error 
