### PR TITLE
Fix save feature

### DIFF
--- a/glade/oscplot.glade
+++ b/glade/oscplot.glade
@@ -1716,7 +1716,7 @@
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">3</property>
           </packing>

--- a/oscplot.c
+++ b/oscplot.c
@@ -4504,7 +4504,7 @@ static void copy_channel_state_to_selection_channel(GtkTreeModel *model,
 	for (node = ch_checkbtns; node; node = g_list_next(node)) {
 		btn = (GtkToggleButton *)node->data;
 		g_object_get(btn, "label", &btn_label, NULL);
-		if (!strcmp(ch_name, btn_label)) {
+		if (!strcmp(ch_name, btn_label) && !iio_channel_is_output(chn)) {
 			gtk_toggle_button_set_active(btn, active_state);
 			g_free(btn_label);
 			break;

--- a/oscplot.c
+++ b/oscplot.c
@@ -4436,13 +4436,15 @@ static void plot_destroyed (GtkWidget *object, OscPlot *plot)
 static GdkPixbuf * window_get_screenshot_pixbuf(GtkWidget *window)
 {
 	GdkWindow *gdk_w;
+	GtkAllocation allocation;
 	gint width, height;
 
 	gdk_w = gtk_widget_get_window(window);
+	gtk_widget_get_allocation(window, &allocation);
 	width = gdk_window_get_width(gdk_w);
 	height = gdk_window_get_height(gdk_w);
 
-	return gdk_pixbuf_get_from_window(gdk_w, 0, 0, width, height);
+	return gdk_pixbuf_get_from_window(gdk_w, allocation.x, allocation.y, width, height);
 }
 
 static void screenshot_saveas_png(OscPlot *plot)


### PR DESCRIPTION
This includes the following fixes: 
- exapand channel list in save_as dialog so all channels are visible
- use allocation widget to get the position of osc plot window when screenshotting(saving to PNG)
- check data written to CSV,MAT,VSA files is coming only from input channels
- make sure only input channels are displayed in save_as list (temporary fix)
