### PR TITLE
plugins: adrv9002: fix out of bounds access

### DIFF
--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -475,7 +475,7 @@ struct carrier_helper {
 	struct {
 		struct adrv9002_combo_box *ensm;
 		gchar *old;
-	} s[3]; /* can't have more than 3 other ports on the same LO */
+	} s[ADRV9002_NUM_CHANNELS * 2];
 	int n_restore;
 };
 


### PR DESCRIPTION
The array in 'struct carrier_helper' needs to be increased to the max number of channels. The assumption of 3 being the max possible number is no longer true. After
commit a2c666aa9ac58 ("plugins: adrv9002: fix carrier handling"), we can have all ports moved to calibrated state using that helper struct (when all ports are on the same LO). Hence, we could run into an out of bounds access. On arch (as all packages and hence gtk are build with -fstack-clash-protection) we, at least, get the program aborted with stack smashing protection abort.

---

Note that on master we don't need the fix since commit 6639701cf348 implicitly fixed it.