### PR TITLE
Fix Detailed SPI Reg Map on windows

### DIFF
--- a/CI/docker/install_prep.sh
+++ b/CI/docker/install_prep.sh
@@ -86,6 +86,7 @@ bin_dir() {
 	cp -r $WORKDIR/iio-oscilloscope/glade $WORKDIR/iio-oscilloscope/build/bin/
 	cp -r $WORKDIR/iio-oscilloscope/block_diagrams $WORKDIR/iio-oscilloscope/build/bin/
 	cp -r $WORKDIR/iio-oscilloscope/icons $WORKDIR/iio-oscilloscope/build/bin/
+	cp -r $WORKDIR/iio-oscilloscope/xmls $WORKDIR/iio-oscilloscope/build/bin/
 	popd
 }
 
@@ -98,7 +99,6 @@ lib_dir() {
 	cp -r $WORKDIR/iio-oscilloscope/filters $WORKDIR/iio-oscilloscope/build/lib/osc
 	cp -r $WORKDIR/iio-oscilloscope/build/profiles $WORKDIR/iio-oscilloscope/build/lib/osc
 	cp -r $WORKDIR/iio-oscilloscope/waveforms $WORKDIR/iio-oscilloscope/build/lib/osc
-	cp -r $WORKDIR/iio-oscilloscope/xmls $WORKDIR/iio-oscilloscope/build/lib/osc
 	cp $WORKDIR/iio-oscilloscope/build/plugins/*.dll $WORKDIR/iio-oscilloscope/build/lib/osc
 	popd
 }


### PR DESCRIPTION
When creating directory hierarchy  for windows installer, copy xmls directory to the bin directory. This ensures that osc is able to find the xml files which produce the detailed SPI Reg Map. 
This fixes the issue where the detailed reg map is not visible on windows. 