### PR TITLE
xml_utils: explicitly include <stdlib.h>

### DIFF
--- a/xml_utils.c
+++ b/xml_utils.c
@@ -7,6 +7,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <dirent.h>
 #include <string.h>
 #include <libxml/xmlmemory.h>


### PR DESCRIPTION
Building osc in arch linux started to fail because of warnings being treated as errors:

"
error: implicit declaration of function ‘calloc’ [-Werror=implicit-function-declaration]
  188 |                 text = (char *)calloc(1, sizeof(char)); /* Create an empty string */
      |                                ^~~~~~
note: include ‘<stdlib.h>’ or provide a declaration of ‘calloc’
error: incompatible implicit declaration of built-in function ‘calloc’ [-Werror=builtin-declaration-mismatch]
"

The likely reason is that stdlib.h was somehow being indirectly included and maybe a change in libxml changed that. Hence, let's just explicitly include the needed header.