### PR TITLE
osc: Implement a way to provide custom algorithm for XY plot

### DIFF
--- a/datatypes.h
+++ b/datatypes.h
@@ -150,6 +150,9 @@ struct _constellation_settings {
 	gfloat *x_source;
 	gfloat *y_source;
 	unsigned int num_samples;
+	void (*xy_transform)(gfloat *x_in, gfloat *y_in, gfloat *x_out, gfloat *y_out,
+			unsigned int length, void *user_data); /* optional */
+	void *xy_transform_user_data; /* optional */
 };
 
 struct _cross_correlation_settings {

--- a/oscplot.h
+++ b/oscplot.h
@@ -76,6 +76,8 @@ void          osc_plot_spect_mode       (OscPlot *plot, bool enable);
 void          osc_plot_spect_set_start_f(OscPlot *plot, double freq_mhz);
 void          osc_plot_spect_set_len    (OscPlot *plot, unsigned fft_count);
 void          osc_plot_spect_set_filter_bw(OscPlot *plot, double bw);
+void          osc_plot_set_xy_transform (OscPlot *plot, void (*xy_transform)(gfloat *x_in, gfloat *y_in,
+				gfloat *x_out, gfloat *y_out, unsigned int length, void *user_data), void *user_data);
 
 G_END_DECLS
 


### PR DESCRIPTION
Usage example:
/* define the routine with the algorithm */
static void my_xy_transform(gfloat *x_in, gfloat *y_in, gfloat *x_out, gfloat *y_out,
	unsigned int length, void *user_data)
{
	unsigned int i;
	for (i = 0; i < length; ++i) {
		x_out[i] = some_custom_algorithm(x_in[i]);
		y_out[i] = some_custom_algorithm(y_in[i]);
	}
}

/* Look for an already created plot instance that is configured to display XY data. Then, configure it to call your routine. Make sure that the plot is stopped the first time you set the routine. This is to tell the plot to create some internal buffers first. */
bool plot_is_running = false;
OscPlot *xy_plot = plugin_find_plot_with_domain(XY_PLOT); if (xy_plot) {
	plot_is_running = osc_plot_running_state(xy_plot);
	if (!plot_is_running) {
		osc_plot_set_xy_transform(xy_plot, my_xy_transform, NULL);
	}
}