### PR TITLE
Replace deprecated GTK functions

### DIFF
--- a/dialogs.c
+++ b/dialogs.c
@@ -302,6 +302,7 @@ static bool widget_set_cursor(GtkWidget *widget, GdkCursorType type)
 {
 	GdkCursor *watchCursor;
 	GdkWindow *gdkWindow;
+	GdkDisplay *display;
 
 	g_return_val_if_fail(widget, false);
 
@@ -313,7 +314,8 @@ static bool widget_set_cursor(GtkWidget *widget, GdkCursorType type)
 
 	g_return_val_if_fail(gdkWindow, false);
 
-	watchCursor = gdk_cursor_new(type);
+	display = gdk_window_get_display(gdkWindow);
+	watchCursor = gdk_cursor_new_for_display(display, type);
 	gdk_window_set_cursor(gdkWindow, watchCursor);
 
 	while (gtk_events_pending())

--- a/osc.c
+++ b/osc.c
@@ -471,8 +471,12 @@ void move_gtk_window_on_screen(GtkWindow   *window,
 	// get screen dimensions
 	GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(window));
 	GdkScreen *screen = gdk_window_get_screen(gdk_window);
-	gint screen_w = gdk_screen_get_width(screen);
-	gint screen_h = gdk_screen_get_height(screen);
+	GdkDisplay *display = gdk_screen_get_display(screen);
+	GdkMonitor *monitor = gdk_display_get_monitor_at_window(display, gdk_window);
+	GdkRectangle geometry;
+	gdk_monitor_get_geometry(monitor, &geometry);
+	gint screen_w = geometry.width;
+	gint screen_h = geometry.height;
 
 	gint window_w;
 	gint window_h;

--- a/oscplot.c
+++ b/oscplot.c
@@ -6876,11 +6876,11 @@ static void fullscreen_changed_cb(GtkWidget *widget, OscPlot *plot)
 
      if (priv->fullscreen_state) {
          gtk_window_unfullscreen(GTK_WINDOW(priv->window));
-         gtk_tool_button_set_stock_id(GTK_TOOL_BUTTON(priv->fullscreen_button), "gtk-fullscreen");
+         gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(priv->fullscreen_button), "gtk-fullscreen");
          gtk_menu_item_set_label(GTK_MENU_ITEM(priv->menu_fullscreen), "Fullscreen");
      } else {
          gtk_window_fullscreen(GTK_WINDOW(priv->window));
-         gtk_tool_button_set_stock_id(GTK_TOOL_BUTTON(priv->fullscreen_button), "gtk-leave-fullscreen");
+         gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(priv->fullscreen_button), "gtk-leave-fullscreen");
          gtk_menu_item_set_label(GTK_MENU_ITEM(priv->menu_fullscreen), "Leave Fullscreen");
      }
 }

--- a/plugins/adrv9009.c
+++ b/plugins/adrv9009.c
@@ -1083,7 +1083,13 @@ void buildTabsInContainer(GtkBox *container_box, enum plugin_section section, bo
 		if (!gtk_widget_get_parent(content_widget)) {
 			gtk_box_pack_start(GTK_BOX(page_container), content_widget, FALSE, TRUE, 0);
 		} else {
-			gtk_widget_reparent(content_widget, page_container);
+			GtkWidget *parent = gtk_widget_get_parent(GTK_WIDGET(content_widget));
+			gtk_widget_hide(GTK_WIDGET(content_widget));
+			g_object_ref(GTK_WIDGET(content_widget));
+			gtk_container_remove(GTK_CONTAINER(parent), GTK_WIDGET(content_widget));
+			gtk_container_add(GTK_CONTAINER(page_container), GTK_WIDGET(content_widget));
+			g_object_unref(GTK_WIDGET(content_widget));
+			gtk_widget_show(GTK_WIDGET(content_widget));
 		}
 	}
 

--- a/plugins/dac_data_manager.c
+++ b/plugins/dac_data_manager.c
@@ -895,8 +895,10 @@ static GtkWidget *gui_tone_create(struct dds_tone *tone)
 	tone->freq = spin_button_create(0.0, 100.0, 1.0, FREQUENCY_SPIN_DIGITS);
 	tone->phase = spin_button_create(0.0, 360.0, 1.0, PHASE_SPIN_DIGITS);
 
-	gtk_misc_set_alignment(GTK_MISC(freq), 0.0, 0.5);
-	gtk_misc_set_alignment(GTK_MISC(phase), 0.0, 0.5);
+	gtk_widget_set_halign((GtkWidget*)freq, 0.5);
+	gtk_widget_set_valign((GtkWidget*)freq, 0.0);
+	gtk_widget_set_halign((GtkWidget*)phase, 0.5);
+	gtk_widget_set_valign((GtkWidget*)phase, 0.0);
 
 	if (combobox_scales) {
 		scale = gtk_label_new("Scale:");
@@ -904,7 +906,8 @@ static GtkWidget *gui_tone_create(struct dds_tone *tone)
 	} else {
 		scale = gtk_label_new("Scale(dBFS):");
 		tone->scale = spin_button_create(-91.0, 0.0, 1.0, SCALE_SPIN_DIGITS);
-		gtk_misc_set_alignment(GTK_MISC(scale), 0.0, 0.5);
+		gtk_widget_set_halign((GtkWidget*)scale, 0.5);
+		gtk_widget_set_valign((GtkWidget*)scale, 0.0);
 		gtk_spin_button_set_numeric(GTK_SPIN_BUTTON(tone->scale), FALSE);
 	}
 

--- a/plugins/debug.c
+++ b/plugins/debug.c
@@ -1000,11 +1000,18 @@ static void draw_reg_map(int valid_register)
 	const gchar *label_str;
 	char buf[12];
 	GtkRequisition r;
+	GtkWidget *parent;
 
 	block_bit_option_signals();
 	/* Reset all bits to the "reseverd" status and clear all options */
 	for (i = (reg_bit_width - 1); i >= 0; i--){
-		gtk_widget_reparent(lbl_bits[i], hboxes[i]);
+		parent = gtk_widget_get_parent(GTK_WIDGET(lbl_bits[i]));
+		gtk_widget_hide(GTK_WIDGET(lbl_bits[i]));
+		g_object_ref(GTK_WIDGET(lbl_bits[i]));
+		gtk_container_remove(GTK_CONTAINER(parent), GTK_WIDGET(lbl_bits[i]));
+		gtk_container_add(GTK_CONTAINER(hboxes[i]), GTK_WIDGET(lbl_bits[i]));
+		g_object_unref(GTK_WIDGET(lbl_bits[i]));
+		gtk_widget_show(GTK_WIDGET(lbl_bits[i]));
 		gtk_label_set_text((GtkLabel *)bit_descrip_list[i], "Reserved");
 		gtk_label_set_width_chars((GtkLabel *)bit_descrip_list[i], 13);
 		gtk_combo_box_text_remove_all(GTK_COMBO_BOX_TEXT(bit_comboboxes[i]));
@@ -1046,8 +1053,14 @@ static void draw_reg_map(int valid_register)
 	for (i = 0; i < p_reg->bgroup_cnt; i++){
 		p_bit = &p_reg->bgroup_list[i];
 		for (j = (p_bit->width - 1); j >= 0 ; j--){
-			gtk_widget_reparent(lbl_bits[p_bit->offset + j], hboxes[p_bit->offset]);
-			gtk_box_reorder_child((GtkBox *)hboxes[p_bit->offset], lbl_bits[p_bit->offset + j], -1);
+			parent = gtk_widget_get_parent(GTK_WIDGET(lbl_bits[p_bit->offset + j]));
+			gtk_widget_hide(GTK_WIDGET(lbl_bits[p_bit->offset + j]));
+			g_object_ref(GTK_WIDGET(lbl_bits[p_bit->offset + j]));
+			gtk_container_remove(GTK_CONTAINER(parent), GTK_WIDGET(lbl_bits[p_bit->offset + j]));
+			gtk_container_add(GTK_CONTAINER(hboxes[p_bit->offset]), GTK_WIDGET(lbl_bits[p_bit->offset + j]));
+			g_object_unref(GTK_WIDGET(lbl_bits[p_bit->offset + j]));
+			gtk_box_reorder_child(GTK_BOX(hboxes[p_bit->offset]), GTK_WIDGET(lbl_bits[p_bit->offset + j]), -1);
+			gtk_widget_show(GTK_WIDGET(lbl_bits[p_bit->offset + j]));
 			if (j > 0)
 				gtk_widget_hide(elem_frames[p_bit->offset + j]);
 		}
@@ -1101,7 +1114,7 @@ static void draw_reg_map(int valid_register)
 	}
 
 	/* Set the height of the regmap scrolled window. */
-	gtk_widget_size_request(reg_map_container, &r);
+	gtk_widget_get_preferred_size(reg_map_container, NULL, &r);
 	gtk_widget_set_size_request(scrollwin_regmap, -1, r.height);
 
 	unblock_bit_option_signals();
@@ -1196,7 +1209,8 @@ static void create_reg_map(void)
 		gtk_widget_set_size_request(lbl_bits[i], 50, -1);
 		gtk_box_pack_start((GtkBox *)hboxes[i], lbl_bits[i], TRUE, FALSE,
 									0);
-		gtk_misc_set_alignment((GtkMisc *)lbl_bits[i], 0.5, 0.0);
+		gtk_widget_set_halign((GtkWidget*)lbl_bits[i], 0.5);
+		gtk_widget_set_valign((GtkWidget*)lbl_bits[i], 0.5);
 		bit_descrip_list[i] = gtk_label_new("Reserved");
 		gtk_box_pack_start((GtkBox *)vboxes[i], bit_descrip_list[i], TRUE, TRUE,
 									0);
@@ -1217,11 +1231,18 @@ static void create_reg_map(void)
 		gtk_widget_set_size_request(bit_no_read_lbl[i], 50, -1);
 		gtk_box_pack_start((GtkBox *)vboxes[i], bit_no_read_lbl[i],
 							FALSE, FALSE, 0);
-		gtk_misc_set_padding((GtkMisc *)bit_no_read_lbl[i], 0, 10);
+		gtk_widget_set_margin_start((GtkWidget *)bit_no_read_lbl[i], 0);
+		gtk_widget_set_margin_end((GtkWidget *)bit_no_read_lbl[i], 0);
+		gtk_widget_set_margin_top((GtkWidget *)bit_no_read_lbl[i], 10);
+		gtk_widget_set_margin_bottom((GtkWidget *)bit_no_read_lbl[i], 10);
 
 		gtk_label_set_line_wrap((GtkLabel *)bit_descrip_list[i], TRUE);
-		gtk_misc_set_alignment((GtkMisc *)bit_descrip_list[i], 0.5, 0.5);
-		gtk_misc_set_padding((GtkMisc *)bit_descrip_list[i], 0, 10);
+		gtk_widget_set_halign((GtkWidget*)bit_descrip_list[i], 0.5);
+		gtk_widget_set_valign((GtkWidget*)bit_descrip_list[i], 0.5);
+		gtk_widget_set_margin_start((GtkWidget *)bit_descrip_list[i], 0);
+		gtk_widget_set_margin_end((GtkWidget *)bit_descrip_list[i], 0);
+		gtk_widget_set_margin_top((GtkWidget *)bit_descrip_list[i], 10);
+		gtk_widget_set_margin_bottom((GtkWidget *)bit_descrip_list[i], 10);
 
 		combo_hid_list[i] = g_signal_connect(G_OBJECT(bit_comboboxes[i]),
 			"changed", G_CALLBACK(spin_or_combo_changed_cb), NULL);

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,9 @@
 .data_box {
     background: #000000;
 }
+.spci_box_r {
+	background: #FF0000
+}
+.spci_box_g {
+	background: #008000
+}


### PR DESCRIPTION
Replaced most deprecated gtk3 functions 
The threading methods gdk_threads_init, gdk_threads_enter, gdk_threads_leave will be addressed in a separate PR. These require a greater change within the application code.
