### PR TITLE
CMakeLists: add Wno-error=deprecated flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ add_compile_options(-Wall -Wextra -Werror
 	-Wno-unused-parameter
 	-Wno-error=unused-but-set-variable
 	-Wno-error=unused-function
+	-Wno-error=deprecated
 	-Wimplicit-fallthrough
 	-Wvla
 	-std=gnu90


### PR DESCRIPTION
this flag enables compiling of osc with clang 
this will be removed once gdk threading issues are addressed