### PR TITLE
adrv9002 plugin fix for disabled channels

### DIFF
--- a/glade/adrv9002.glade
+++ b/glade/adrv9002.glade
@@ -3834,26 +3834,41 @@
                                                       </packing>
                                                     </child>
                                                     <child>
-                                                      <object class="GtkBox">
+                                                      <object class="GtkFrame" id="frame_rx1_controls">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
+                                                        <property name="label-xalign">0</property>
+                                                        <property name="shadow-type">none</property>
                                                         <child>
-                                                          <object class="GtkLabel">
+                                                          <object class="GtkAlignment">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="orientation">vertical</property>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Frequency Offset Correction:</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkCheckButton" id="cb_rx_chan1_correction">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkCheckButton" id="cb_rx_chan1_correction">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">True</property>
                                                             <property name="receives-default">False</property>
@@ -3861,151 +3876,152 @@
                                                             <property name="margin-bottom">6</property>
                                                             <property name="use-stock">True</property>
                                                             <property name="draw-indicator">True</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">0</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Bandwidth (Hz):</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cb_rx_chan1_bw">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkComboBoxText" id="cb_rx_chan1_bw">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="has-entry">True</property>
-                                                            <child internal-child="entry">
-                                                            <object class="GtkEntry" id="cb_rx_chan1_bw_entry">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="max-length">8</property>
-                                                            <property name="width-chars">8</property>
                                                             </object>
-                                                            </child>
-                                                          </object>
-                                                          <packing>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">1</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Interface Sample Rate (Hz):</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cb_rx_chan1_interface">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkComboBoxText" id="cb_rx_chan1_interface">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="has-entry">True</property>
-                                                            <child internal-child="entry">
-                                                            <object class="GtkEntry" id="cb_rx_chan1_interface_entry">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="max-length">8</property>
-                                                            <property name="width-chars">8</property>
                                                             </object>
-                                                            </child>
-                                                          </object>
-                                                          <packing>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">3</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">2</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">RX RF Input:</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cb_rx_chan1_rf_port">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkComboBoxText" id="cb_rx_chan1_rf_port">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <items>
                                                             <item id="0" translatable="yes">Rx1A</item>
                                                             <item id="1" translatable="yes">Rx1B</item>
                                                             </items>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">3</property>
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            </child>
+                                                          </object>
+                                                        </child>
+                                                        <child type="label">
+                                                          <object class="GtkLabel">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                          </object>
                                                         </child>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">False</property>
                                                         <property name="fill">True</property>
-                                                        <property name="position">4</property>
+                                                        <property name="position">5</property>
                                                       </packing>
                                                     </child>
                                                   </object>
@@ -4089,26 +4105,41 @@
                                                       </packing>
                                                     </child>
                                                     <child>
-                                                      <object class="GtkBox">
+                                                      <object class="GtkFrame" id="frame_rx2_controls">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
+                                                        <property name="label-xalign">0</property>
+                                                        <property name="shadow-type">none</property>
                                                         <child>
-                                                          <object class="GtkLabel">
+                                                          <object class="GtkAlignment">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="orientation">vertical</property>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Frequency Offset Correction:</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkCheckButton" id="cb_rx_chan2_correction">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkCheckButton" id="cb_rx_chan2_correction">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">True</property>
                                                             <property name="receives-default">False</property>
@@ -4116,151 +4147,152 @@
                                                             <property name="margin-bottom">6</property>
                                                             <property name="use-stock">True</property>
                                                             <property name="draw-indicator">True</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">0</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Bandwidth (Hz):</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cb_rx_chan2_bw">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkComboBoxText" id="cb_rx_chan2_bw">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="has-entry">True</property>
-                                                            <child internal-child="entry">
-                                                            <object class="GtkEntry" id="cb_rx_chan2_bw_entry">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="max-length">8</property>
-                                                            <property name="width-chars">8</property>
                                                             </object>
-                                                            </child>
-                                                          </object>
-                                                          <packing>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">1</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Interface Sample Rate (Hz):</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cb_rx_chan2_interface">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkComboBoxText" id="cb_rx_chan2_interface">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="has-entry">True</property>
-                                                            <child internal-child="entry">
-                                                            <object class="GtkEntry" id="cb_rx_chan2_interface_entry">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="max-length">8</property>
-                                                            <property name="width-chars">8</property>
                                                             </object>
-                                                            </child>
-                                                          </object>
-                                                          <packing>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">3</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">2</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">RX RF Input:</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cb_rx_chan2_rf_port">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkComboBoxText" id="cb_rx_chan2_rf_port">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <items>
                                                             <item id="0" translatable="yes">Rx2A</item>
                                                             <item id="1" translatable="yes">Rx2B</item>
                                                             </items>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">3</property>
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            </child>
+                                                          </object>
+                                                        </child>
+                                                        <child type="label">
+                                                          <object class="GtkLabel">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                          </object>
                                                         </child>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">False</property>
                                                         <property name="fill">True</property>
-                                                        <property name="position">4</property>
+                                                        <property name="position">5</property>
                                                       </packing>
                                                     </child>
                                                   </object>
@@ -4358,26 +4390,41 @@
                                                       </packing>
                                                     </child>
                                                     <child>
-                                                      <object class="GtkBox">
+                                                      <object class="GtkFrame" id="frame_tx1_controls">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
+                                                        <property name="label-xalign">0</property>
+                                                        <property name="shadow-type">none</property>
                                                         <child>
-                                                          <object class="GtkLabel">
+                                                          <object class="GtkAlignment">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="orientation">vertical</property>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Frequency Offset Correction:</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkCheckButton" id="cb_tx_chan1_correction">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkCheckButton" id="cb_tx_chan1_correction">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">True</property>
                                                             <property name="receives-default">False</property>
@@ -4385,110 +4432,111 @@
                                                             <property name="margin-bottom">6</property>
                                                             <property name="use-stock">True</property>
                                                             <property name="draw-indicator">True</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">0</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Bandwidth (Hz):</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cb_tx_chan1_bw">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkComboBoxText" id="cb_tx_chan1_bw">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="has-entry">True</property>
-                                                            <child internal-child="entry">
-                                                            <object class="GtkEntry" id="cb_tx_chan1_bw_entry">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="max-length">8</property>
-                                                            <property name="width-chars">8</property>
                                                             </object>
-                                                            </child>
-                                                          </object>
-                                                          <packing>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel" id="labelTxChanInterface">
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">1</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel" id="labelTxChanInterface">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Interface Sample Rate (Hz):</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cb_tx_chan1_interface">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkComboBoxText" id="cb_tx_chan1_interface">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="has-entry">True</property>
-                                                            <child internal-child="entry">
-                                                            <object class="GtkEntry" id="cb_tx_chan1_interface_entry">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="max-length">8</property>
-                                                            <property name="width-chars">8</property>
                                                             </object>
-                                                            </child>
-                                                          </object>
-                                                          <packing>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">2</property>
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            </child>
+                                                          </object>
+                                                        </child>
+                                                        <child type="label">
+                                                          <object class="GtkLabel">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                          </object>
                                                         </child>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">False</property>
                                                         <property name="fill">True</property>
-                                                        <property name="position">3</property>
+                                                        <property name="position">4</property>
                                                       </packing>
                                                     </child>
                                                   </object>
@@ -4572,26 +4620,42 @@
                                                       </packing>
                                                     </child>
                                                     <child>
-                                                      <object class="GtkBox">
+                                                      <object class="GtkFrame" id="frame_tx2_controls">
                                                         <property name="visible">True</property>
                                                         <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
+                                                        <property name="label-xalign">0</property>
+                                                        <property name="shadow-type">none</property>
                                                         <child>
-                                                          <object class="GtkLabel">
+                                                          <object class="GtkAlignment">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="left-padding">12</property>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="orientation">vertical</property>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Frequency Offset Correction:</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkCheckButton" id="cb_tx_chan2_correction">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkCheckButton" id="cb_tx_chan2_correction">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">True</property>
                                                             <property name="receives-default">False</property>
@@ -4599,110 +4663,111 @@
                                                             <property name="margin-bottom">6</property>
                                                             <property name="use-stock">True</property>
                                                             <property name="draw-indicator">True</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">1</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel">
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">0</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Bandwidth (Hz):</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cb_tx_chan2_bw">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkComboBoxText" id="cb_tx_chan2_bw">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="has-entry">True</property>
-                                                            <child internal-child="entry">
-                                                            <object class="GtkEntry" id="cb_tx_chan2_bw_entry">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="max-length">8</property>
-                                                            <property name="width-chars">8</property>
                                                             </object>
-                                                            </child>
-                                                          </object>
-                                                          <packing>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
-                                                        </child>
-                                                      </object>
-                                                      <packing>
-                                                        <property name="expand">False</property>
-                                                        <property name="fill">True</property>
-                                                        <property name="position">2</property>
-                                                      </packing>
-                                                    </child>
-                                                    <child>
-                                                      <object class="GtkBox">
-                                                        <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="spacing">12</property>
-                                                        <property name="homogeneous">True</property>
-                                                        <child>
-                                                          <object class="GtkLabel" id="labelTxChanInterface1">
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">1</property>
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkBox">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                            <property name="spacing">12</property>
+                                                            <property name="homogeneous">True</property>
+                                                            <child>
+                                                            <object class="GtkLabel" id="labelTxChanInterface1">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="halign">end</property>
                                                             <property name="label" translatable="yes">Interface Sample Rate (Hz):</property>
-                                                          </object>
-                                                          <packing>
+                                                            </object>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">0</property>
-                                                          </packing>
-                                                        </child>
-                                                        <child>
-                                                          <object class="GtkComboBoxText" id="cb_tx_chan2_interface">
+                                                            </packing>
+                                                            </child>
+                                                            <child>
+                                                            <object class="GtkComboBoxText" id="cb_tx_chan2_interface">
                                                             <property name="visible">True</property>
                                                             <property name="can-focus">False</property>
                                                             <property name="has-entry">True</property>
-                                                            <child internal-child="entry">
-                                                            <object class="GtkEntry" id="cb_tx_chan2_interface_entry">
-                                                            <property name="visible">True</property>
-                                                            <property name="can-focus">True</property>
-                                                            <property name="max-length">8</property>
-                                                            <property name="width-chars">8</property>
                                                             </object>
-                                                            </child>
-                                                          </object>
-                                                          <packing>
+                                                            <packing>
                                                             <property name="expand">False</property>
                                                             <property name="fill">True</property>
                                                             <property name="position">1</property>
-                                                          </packing>
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            <packing>
+                                                            <property name="expand">False</property>
+                                                            <property name="fill">True</property>
+                                                            <property name="position">2</property>
+                                                            </packing>
+                                                            </child>
+                                                            </object>
+                                                            </child>
+                                                          </object>
+                                                        </child>
+                                                        <child type="label">
+                                                          <object class="GtkLabel">
+                                                            <property name="visible">True</property>
+                                                            <property name="can-focus">False</property>
+                                                          </object>
                                                         </child>
                                                       </object>
                                                       <packing>
                                                         <property name="expand">False</property>
                                                         <property name="fill">True</property>
-                                                        <property name="position">3</property>
+                                                        <property name="position">4</property>
                                                       </packing>
                                                     </child>
                                                   </object>

--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -2400,6 +2400,21 @@ static int profile_gen_ui_refresh(GtkButton *self, struct plugin_private *priv)
 	return 0;
 }
 
+static void profile_gen_update_channels(GtkComboBox *self, struct plugin_private *priv)
+{
+	GtkWidget *channel_frame;
+	bool channel_en;
+	unsigned long i;
+	char *ch_frames[4] = {"frame_tx1_controls", "frame_tx2_controls", "frame_rx1_controls", "frame_rx2_controls"};
+	char *ch_buttons[4] = {"cb_tx_chan1_en", "cb_tx_chan2_en", "cb_rx_chan1_en", "cb_rx_chan2_en"};
+
+	for (i = 0; i < ARRAY_SIZE(ch_frames); i++) {
+		channel_frame = GTK_WIDGET(gtk_builder_get_object(priv->builder, ch_frames[i]));
+		channel_en = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gtk_builder_get_object(priv->builder, ch_buttons[i])));
+		gtk_widget_set_sensitive(channel_frame, channel_en);
+	}
+}
+
 static void adrv9002_combo_box_init(struct iio_widget *combo, const char *w_str,
 				    const char *attr, const char *attr_avail,
 				    struct plugin_private *priv, struct iio_channel *chann)
@@ -3053,6 +3068,19 @@ static GtkWidget *adrv9002_init(struct osc_plugin *plugin, GtkWidget *notebook,
 		/* refresh on preset changed */
 		g_builder_connect_signal(priv->builder, "cb_preset", "changed",
 					 G_CALLBACK(profile_gen_ui_refresh), priv);
+
+		/* update channel controls sensitivity */
+		g_builder_connect_signal(priv->builder, "cb_tx_chan1_en", "toggled",
+					 G_CALLBACK(profile_gen_update_channels), priv);
+
+		g_builder_connect_signal(priv->builder, "cb_tx_chan2_en", "toggled",
+					 G_CALLBACK(profile_gen_update_channels), priv);
+
+		g_builder_connect_signal(priv->builder, "cb_rx_chan1_en", "toggled",
+					 G_CALLBACK(profile_gen_update_channels), priv);
+
+		g_builder_connect_signal(priv->builder, "cb_rx_chan2_en", "toggled",
+					 G_CALLBACK(profile_gen_update_channels), priv);
 
 	} else {
 		gtk_widget_set_sensitive(GTK_WIDGET(gtk_builder_get_object(priv->builder, "boxProfileGen")), false);

--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -173,120 +173,6 @@ typedef struct adrv9002_config
 	clock_config clk_cfg;
 } adrv9002_config;
 
-static adrv9002_config lte_defaults(void)
-{
-	radio_config radio_config;
-	radio_config.ssi_lanes = 2;
-	radio_config.ddr = true; // needs logic
-	radio_config.short_strobe = true;
-	radio_config.lvds = true;
-	radio_config.adc_rate_mode = 3;
-	radio_config.fdd = false;
-
-	tx_radio_channel_config tx_config[2];
-	int i;
-	for(i = 0; i < CHANNEL_COUNT; i++) {
-		tx_config[i].enabled = true;
-		tx_config[i].sample_rate_hz = 61440000;
-		tx_config[i].frequency_offset_correction_enable = false;
-		tx_config[i].analog_filter_power_mode = 2;
-		tx_config[i].channel_bandwidth_hz = 38000000;
-		tx_config[i].elb_type = 0;
-		tx_config[i].orx_enabled = false;
-
-		radio_config.tx_config[i] = tx_config[i];
-	}
-
-	rx_radio_channel_config rx_config[2];
-	for(i = 0; i < CHANNEL_COUNT; i++) {
-		rx_config[i].enabled = true;
-		rx_config[i].sample_rate_hz = 61440000;
-		rx_config[i].frequency_offset_correction_enable = false;
-		rx_config[i].analog_filter_power_mode = 2;
-		rx_config[i].channel_bandwidth_hz = 38000000;
-		rx_config[i].adc_high_performance_mode = true;
-		rx_config[i].analog_filter_biquad = false;	    // got from default cfg
-		rx_config[i].analog_filter_bandwidth_hz = 18000000; // got from default cfg
-		rx_config[i].nco_enable = false;
-		rx_config[i].nco_frequency_hz = 0;
-		rx_config[i].rf_port = 0;
-
-		radio_config.rx_config[i] = rx_config[i];
-	}
-	adrv9002_config cfg;
-	cfg.radio_cfg = radio_config;
-
-	clock_config clock_config;
-	clock_config.device_clock_frequency_khz = 38400;
-	clock_config.device_clock_output_enable = true;
-	clock_config.device_clock_output_divider = 2;
-	clock_config.clock_pll_high_performance_enable = false;
-	clock_config.clock_pll_power_mode = 2;
-	clock_config.processor_clock_divider = 1;
-
-	cfg.clk_cfg = clock_config;
-	return cfg;
-}
-
-static adrv9002_config lte_lvs_3072_MHz_10(void)
-{
-	rx_radio_channel_config rx1;
-	rx1.enabled = 1;
-	rx1.adc_high_performance_mode = true;
-	rx1.frequency_offset_correction_enable = false;
-	rx1.analog_filter_power_mode = 2; // High power/performance
-	rx1.analog_filter_biquad = false;
-	rx1.channel_bandwidth_hz = 18000000;
-	rx1.sample_rate_hz = 30720000;
-	rx1.nco_enable = false;
-	rx1.nco_frequency_hz = 0;
-	rx1.rf_port = 0;		    // RX-A
-	rx1.analog_filter_bandwidth_hz = 0; // TODO: not used?
-
-	// Copy rx1 to rx2
-	rx_radio_channel_config rx2 = rx1;
-	rx2.rf_port = 0; // RX-B
-
-	// TX side
-	tx_radio_channel_config tx1;
-	tx1.enabled = 1;
-	tx1.sample_rate_hz = 30720000;
-	tx1.frequency_offset_correction_enable = false;
-	tx1.analog_filter_power_mode = 2; // High power/performance
-	tx1.channel_bandwidth_hz = 18000000;
-	tx1.orx_enabled = true;
-	tx1.elb_type = 2;
-
-	// Copy tx1 to tx2
-	tx_radio_channel_config tx2 = tx1;
-
-	radio_config r_cfg;
-	r_cfg.adc_rate_mode = 3; // High Performance
-	r_cfg.fdd = false;
-	r_cfg.lvds = true;
-	r_cfg.ssi_lanes = 2;
-	r_cfg.ddr = true;
-	r_cfg.adc_rate_mode = 3; // High Performance
-	r_cfg.short_strobe = true;
-	r_cfg.rx_config[0] = rx1;
-	r_cfg.rx_config[1] = rx2;
-	r_cfg.tx_config[0] = tx1;
-	r_cfg.tx_config[1] = tx2;
-
-	clock_config clk_cfg;
-	clk_cfg.device_clock_frequency_khz = 38400;
-	clk_cfg.clock_pll_high_performance_enable = true;
-	clk_cfg.clock_pll_power_mode = 2; // High power/performance
-	clk_cfg.processor_clock_divider = 1;
-	clk_cfg.device_clock_output_divider = 0; // TODO: not used?
-	clk_cfg.device_clock_output_enable = 0;
-
-	adrv9002_config adrv_cfg;
-	adrv_cfg.clk_cfg = clk_cfg;
-	adrv_cfg.radio_cfg = r_cfg;
-
-	return adrv_cfg;
-}
 /*---------------------------------------------------------------------------*/
 
 #ifndef ENOTSUPP
@@ -1204,6 +1090,122 @@ err:
 		gtk_file_chooser_set_filename(chooser, priv->last_profile);
 	else
 		gtk_file_chooser_set_filename(chooser, "(None)");
+}
+
+// profile generator default config structures
+static adrv9002_config lte_defaults(void)
+{
+	tx_radio_channel_config tx1;
+	tx1.enabled = true;
+	tx1.sample_rate_hz = 61440000;
+	tx1.frequency_offset_correction_enable = false;
+	tx1.analog_filter_power_mode = 2;
+	tx1.channel_bandwidth_hz = 38000000;
+	tx1.elb_type = 0;
+	tx1.orx_enabled = false;
+
+	tx_radio_channel_config tx2 = tx1;
+
+	rx_radio_channel_config rx1;
+	rx1.enabled = true;
+	rx1.sample_rate_hz = 61440000;
+	rx1.frequency_offset_correction_enable = false;
+	rx1.analog_filter_power_mode = 2;
+	rx1.channel_bandwidth_hz = 38000000;
+	rx1.adc_high_performance_mode = true;
+	rx1.analog_filter_biquad = false;	    // got from default cfg
+	rx1.analog_filter_bandwidth_hz = 18000000; // got from default cfg
+	rx1.nco_enable = false;
+	rx1.nco_frequency_hz = 0;
+	rx1.rf_port = 0;
+
+	rx_radio_channel_config rx2 = rx1;
+
+	radio_config radio_config;
+	radio_config.ssi_lanes = 2;
+	radio_config.ddr = true; // needs logic
+	radio_config.short_strobe = true;
+	radio_config.lvds = true;
+	radio_config.adc_rate_mode = 3;
+	radio_config.fdd = false;
+	radio_config.tx_config[0] = tx1;
+	radio_config.tx_config[1] = tx2;
+	radio_config.rx_config[0] = rx1;
+	radio_config.rx_config[1] = rx2;
+
+	clock_config clock_config;
+	clock_config.device_clock_frequency_khz = 38400;
+	clock_config.device_clock_output_enable = true;
+	clock_config.device_clock_output_divider = 2;
+	clock_config.clock_pll_high_performance_enable = false;
+	clock_config.clock_pll_power_mode = 2;
+	clock_config.processor_clock_divider = 1;
+
+	adrv9002_config cfg;
+	cfg.radio_cfg = radio_config;
+	cfg.clk_cfg = clock_config;
+
+	return cfg;
+}
+
+static adrv9002_config lte_lvs_3072_MHz_10(void)
+{
+	rx_radio_channel_config rx1;
+	rx1.enabled = 1;
+	rx1.adc_high_performance_mode = true;
+	rx1.frequency_offset_correction_enable = false;
+	rx1.analog_filter_power_mode = 2; // High power/performance
+	rx1.analog_filter_biquad = false;
+	rx1.channel_bandwidth_hz = 18000000;
+	rx1.sample_rate_hz = 30720000;
+	rx1.nco_enable = false;
+	rx1.nco_frequency_hz = 0;
+	rx1.rf_port = 0;		    // RX-A
+	rx1.analog_filter_bandwidth_hz = 0; // TODO: not used?
+
+	// Copy rx1 to rx2
+	rx_radio_channel_config rx2 = rx1;
+	rx2.rf_port = 0; // RX-B
+
+	// TX side
+	tx_radio_channel_config tx1;
+	tx1.enabled = 1;
+	tx1.sample_rate_hz = 30720000;
+	tx1.frequency_offset_correction_enable = false;
+	tx1.analog_filter_power_mode = 2; // High power/performance
+	tx1.channel_bandwidth_hz = 18000000;
+	tx1.orx_enabled = true;
+	tx1.elb_type = 2;
+
+	// Copy tx1 to tx2
+	tx_radio_channel_config tx2 = tx1;
+
+	radio_config r_cfg;
+	r_cfg.adc_rate_mode = 3; // High Performance
+	r_cfg.fdd = false;
+	r_cfg.lvds = true;
+	r_cfg.ssi_lanes = 2;
+	r_cfg.ddr = true;
+	r_cfg.adc_rate_mode = 3; // High Performance
+	r_cfg.short_strobe = true;
+	r_cfg.rx_config[0] = rx1;
+	r_cfg.rx_config[1] = rx2;
+	r_cfg.tx_config[0] = tx1;
+	r_cfg.tx_config[1] = tx2;
+
+	clock_config clk_cfg;
+	clk_cfg.device_clock_frequency_khz = 38400;
+	clk_cfg.clock_pll_high_performance_enable = true;
+	clk_cfg.clock_pll_power_mode = 2; // High power/performance
+	clk_cfg.processor_clock_divider = 1;
+	clk_cfg.device_clock_output_divider = 0; // TODO: not used?
+	clk_cfg.device_clock_output_enable = 0;
+
+	adrv9002_config adrv_cfg;
+	adrv_cfg.clk_cfg = clk_cfg;
+	adrv_cfg.radio_cfg = r_cfg;
+
+	return adrv_cfg;
 }
 
 static void profile_gen_append_debug_info(gpointer data, char *string)

--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -1668,44 +1668,68 @@ static int profile_gen_config_set_live_device(struct adrv9002_config *cfg, gpoin
 	sprintf(str_value, "%d", cfg->radio_cfg.fdd);
 	gtk_combo_box_set_active_id(GTK_COMBO_BOX(gtk_builder_get_object(priv->builder, "cb_radio_duplex")), str_value);
 
-	// RX and TX
-	size_t ch_type;
-	char *ch_types[2] = {"rx", "tx"};
-	for(ch_type = 0; ch_type < ARRAY_SIZE(ch_types); ch_type++) {
-		for(chann = 0; chann < CHANNEL_COUNT; chann++) {
-			// channel_bandwidth_hz
-			sprintf(widget_str, "cb_%s_chan%d_bw", ch_types[ch_type], chann + 1);
-			sprintf(value, "%d", cfg->radio_cfg.rx_config[chann].channel_bandwidth_hz);
-			populate_combo_box(GTK_COMBO_BOX_TEXT(gtk_builder_get_object(priv->builder, widget_str)), NULL, 0, TRUE,
-					   value);
+	// TX
+	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+		// channel_bandwidth_hz
+		sprintf(widget_str, "cb_tx_chan%d_bw", chann + 1);
+		sprintf(value, "%d", cfg->radio_cfg.tx_config[chann].channel_bandwidth_hz);
+		populate_combo_box(GTK_COMBO_BOX_TEXT(gtk_builder_get_object(priv->builder, widget_str)), NULL, 0, TRUE,
+				   value);
 
-			// sample_rate_hz
-			sprintf(widget_str, "cb_%s_chan%d_interface", ch_types[ch_type], chann + 1);
-			sprintf(value, "%d", cfg->radio_cfg.rx_config[chann].sample_rate_hz);
-			populate_combo_box(GTK_COMBO_BOX_TEXT(gtk_builder_get_object(priv->builder, widget_str)), NULL, 0, TRUE,
-					   value);
+		// sample_rate_hz
+		sprintf(widget_str, "cb_tx_chan%d_interface", chann + 1);
+		sprintf(value, "%d", cfg->radio_cfg.tx_config[chann].sample_rate_hz);
+		populate_combo_box(GTK_COMBO_BOX_TEXT(gtk_builder_get_object(priv->builder, widget_str)), NULL, 0, TRUE,
+				   value);
 
-			// enabled
-			sprintf(widget_str, "cb_%s_chan%d_en", ch_types[ch_type], chann + 1);
-			if(reset_preset) {
-				gtk_toggle_button_set_active(
-					GTK_TOGGLE_BUTTON(gtk_builder_get_object(priv->builder, widget_str)),
-					cfg->radio_cfg.rx_config[chann].enabled);
-			}
+		// enabled
+		sprintf(widget_str, "cb_tx_chan%d_en", chann + 1);
+		if(reset_preset) {
+			gtk_toggle_button_set_active(
+				GTK_TOGGLE_BUTTON(gtk_builder_get_object(priv->builder, widget_str)),
+				cfg->radio_cfg.tx_config[chann].enabled);
+		}
 
-			// frequency_offset_correction_enable
-			sprintf(widget_str, "cb_%s_chan%d_correction", ch_types[ch_type], chann + 1);
-			if(reset_preset) {
-				gtk_toggle_button_set_active(
-					GTK_TOGGLE_BUTTON(gtk_builder_get_object(priv->builder, widget_str)),
-					cfg->radio_cfg.rx_config[chann].frequency_offset_correction_enable);
-			}
+		// frequency_offset_correction_enable
+		sprintf(widget_str, "cb_tx_chan%d_correction", chann + 1);
+		if(reset_preset) {
+			gtk_toggle_button_set_active(
+				GTK_TOGGLE_BUTTON(gtk_builder_get_object(priv->builder, widget_str)),
+				cfg->radio_cfg.tx_config[chann].frequency_offset_correction_enable);
 		}
 	}
 
-	// RX specific
-	// rf_port
+	// RX
 	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+		// channel_bandwidth_hz
+		sprintf(widget_str, "cb_rx_chan%d_bw", chann + 1);
+		sprintf(value, "%d", cfg->radio_cfg.rx_config[chann].channel_bandwidth_hz);
+		populate_combo_box(GTK_COMBO_BOX_TEXT(gtk_builder_get_object(priv->builder, widget_str)), NULL, 0, TRUE,
+				   value);
+
+		// sample_rate_hz
+		sprintf(widget_str, "cb_rx_chan%d_interface", chann + 1);
+		sprintf(value, "%d", cfg->radio_cfg.rx_config[chann].sample_rate_hz);
+		populate_combo_box(GTK_COMBO_BOX_TEXT(gtk_builder_get_object(priv->builder, widget_str)), NULL, 0, TRUE,
+				   value);
+
+		// enabled
+		sprintf(widget_str, "cb_rx_chan%d_en", chann + 1);
+		if(reset_preset) {
+			gtk_toggle_button_set_active(
+				GTK_TOGGLE_BUTTON(gtk_builder_get_object(priv->builder, widget_str)),
+				cfg->radio_cfg.rx_config[chann].enabled);
+		}
+
+		// frequency_offset_correction_enable
+		sprintf(widget_str, "cb_rx_chan%d_correction", chann + 1);
+		if(reset_preset) {
+			gtk_toggle_button_set_active(
+				GTK_TOGGLE_BUTTON(gtk_builder_get_object(priv->builder, widget_str)),
+				cfg->radio_cfg.rx_config[chann].frequency_offset_correction_enable);
+		}
+
+		// rf_port
 		sprintf(widget_str, "cb_rx_chan%d_rf_port", chann + 1);
 		sprintf(value, "%d", cfg->radio_cfg.rx_config[chann].rf_port);
 		if(reset_preset) {

--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -67,7 +67,6 @@ typedef struct rx_radio_channel_config
 
 } rx_radio_channel_config;
 
-#define CHANNEL_COUNT 2
 
 /**
  * @struct tx_radio_channel_config
@@ -1262,7 +1261,7 @@ static void profile_gen_update_orx(GtkComboBox *self, struct plugin_private *pri
 
 	tdd_en = atoi(gtk_combo_box_get_active_id(
 			 GTK_COMBO_BOX(gtk_builder_get_object(priv->builder, "cb_radio_duplex")))) == 0;
-	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+	for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 		sprintf(widget_str, "cb_tx_chan%d_en", chann + 1);
 		tx_en = gtk_toggle_button_get_active(
 			GTK_TOGGLE_BUTTON(gtk_builder_get_object(priv->builder, widget_str)));
@@ -1391,7 +1390,7 @@ static int profile_gen_config_get_from_device(struct adrv9002_config *cfg, gpoin
 
 	int chann;
 	char chann_str[32];
-	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+	for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 		sprintf(chann_str, "voltage%d", chann);
 		struct iio_channel *tx = iio_device_find_channel(priv->adrv9002, chann_str, true);
 		if(tx == NULL) {
@@ -1446,7 +1445,7 @@ static int profile_gen_config_get_from_device(struct adrv9002_config *cfg, gpoin
 	// radio_config.rx_config
 	rx_radio_channel_config rx_config[2];
 
-	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+	for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 		sprintf(chann_str, "voltage%d", chann);
 		struct iio_channel *rx = iio_device_find_channel(priv->adrv9002, chann_str, false);
 		if(rx == NULL) {
@@ -1671,7 +1670,7 @@ static int profile_gen_config_set_live_device(struct adrv9002_config *cfg, gpoin
 	gtk_combo_box_set_active_id(GTK_COMBO_BOX(gtk_builder_get_object(priv->builder, "cb_radio_duplex")), str_value);
 
 	// TX
-	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+	for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 		// channel_bandwidth_hz
 		sprintf(widget_str, "cb_tx_chan%d_bw", chann + 1);
 		sprintf(value, "%d", cfg->radio_cfg.tx_config[chann].channel_bandwidth_hz);
@@ -1702,7 +1701,7 @@ static int profile_gen_config_set_live_device(struct adrv9002_config *cfg, gpoin
 	}
 
 	// RX
-	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+	for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 		// channel_bandwidth_hz
 		sprintf(widget_str, "cb_rx_chan%d_bw", chann + 1);
 		sprintf(value, "%d", cfg->radio_cfg.rx_config[chann].channel_bandwidth_hz);
@@ -1798,7 +1797,7 @@ static int profile_gen_config_set_LTE(struct adrv9002_config *cfg, gpointer data
 
 	// sample_rate_hz
 	for(ch_type = 0; ch_type < ARRAY_SIZE(ch_types); ch_type++) {
-		for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+		for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 			sprintf(widget_str, "cb_%s_chan%d_interface", ch_types[ch_type], chann + 1);
 			populate_combo_box(GTK_COMBO_BOX_TEXT(gtk_builder_get_object(priv->builder, widget_str)),
 					   value_list, value_count, false, NULL);
@@ -1816,7 +1815,7 @@ static int profile_gen_config_set_LTE(struct adrv9002_config *cfg, gpointer data
 
 	// channel_bandwidth_hz
 	for(ch_type = 0; ch_type < ARRAY_SIZE(ch_types); ch_type++) {
-		for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+		for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 			sprintf(widget_str, "cb_%s_chan%d_interface", ch_types[ch_type], chann + 1);
 			char *current_sample_rate = gtk_combo_box_text_get_active_text(
 				GTK_COMBO_BOX_TEXT(gtk_builder_get_object(priv->builder, widget_str)));
@@ -1870,7 +1869,7 @@ static int profile_gen_config_set_LTE(struct adrv9002_config *cfg, gpointer data
 
 	// RX and TX
 	for(ch_type = 0; ch_type < ARRAY_SIZE(ch_types); ch_type++) {
-		for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+		for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 			// enabled
 			sprintf(widget_str, "cb_%s_chan%d_en", ch_types[ch_type], chann + 1);
 			if(reset_preset) {
@@ -1891,7 +1890,7 @@ static int profile_gen_config_set_LTE(struct adrv9002_config *cfg, gpointer data
 
 	// RX specific
 	// ft_port
-	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+	for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 		sprintf(widget_str, "cb_rx_chan%d_rf_port", chann + 1);
 		sprintf(value, "%d", cfg->radio_cfg.rx_config[chann].rf_port);
 		if(reset_preset) {
@@ -1971,7 +1970,7 @@ static int profile_gen_config_populate_from_ui(struct adrv9002_config *cfg, gpoi
 		atoi(gtk_combo_box_get_active_id(GTK_COMBO_BOX(gtk_builder_get_object(priv->builder, widget_str))));
 
 	// RX
-	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+	for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 		sprintf(widget_str, "cb_rx_chan%d_bw", chann + 1);
 		cfg->radio_cfg.rx_config[chann].channel_bandwidth_hz =
 			(uint32_t)atoi(gtk_combo_box_text_get_active_text(
@@ -1995,7 +1994,7 @@ static int profile_gen_config_populate_from_ui(struct adrv9002_config *cfg, gpoi
 	}
 
 	// TX
-	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+	for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 		sprintf(widget_str, "cb_tx_chan%d_bw", chann + 1);
 		cfg->radio_cfg.tx_config[chann].channel_bandwidth_hz =
 			(uint32_t)atoi(gtk_combo_box_text_get_active_text(
@@ -2076,7 +2075,7 @@ static char *profile_gen_config_to_str(struct adrv9002_config *cfg)
 
 	// radio_cfg.rx_config
 	cJSON_AddItemToObject(radio_cfg, "rx_config", rx_config = cJSON_CreateArray());
-	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+	for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 		cJSON_AddItemToArray(rx_config, tmp_object = cJSON_CreateObject());
 		cJSON_AddNumberToObject(tmp_object, "enabled", cfg->radio_cfg.rx_config[chann].enabled);
 		cJSON_AddNumberToObject(tmp_object, "adc_high_performance_mode",
@@ -2100,7 +2099,7 @@ static char *profile_gen_config_to_str(struct adrv9002_config *cfg)
 
 	// radio_cfg.tx_config
 	cJSON_AddItemToObject(radio_cfg, "tx_config", tx_config = cJSON_CreateArray());
-	for(chann = 0; chann < CHANNEL_COUNT; chann++) {
+	for(chann = 0; chann < ADRV9002_NUM_CHANNELS; chann++) {
 		cJSON_AddItemToArray(tx_config, tmp_object = cJSON_CreateObject());
 		cJSON_AddNumberToObject(tmp_object, "enabled", cfg->radio_cfg.tx_config[chann].enabled);
 		cJSON_AddNumberToObject(tmp_object, "sample_rate_hz", cfg->radio_cfg.tx_config[chann].sample_rate_hz);
@@ -2407,8 +2406,8 @@ static void profile_gen_update_channels(GtkComboBox *self, struct plugin_private
 	GtkWidget *channel_frame;
 	bool channel_en;
 	unsigned long i;
-	char *ch_frames[4] = {"frame_tx1_controls", "frame_tx2_controls", "frame_rx1_controls", "frame_rx2_controls"};
-	char *ch_buttons[4] = {"cb_tx_chan1_en", "cb_tx_chan2_en", "cb_rx_chan1_en", "cb_rx_chan2_en"};
+	char *ch_frames[] = {"frame_tx1_controls", "frame_tx2_controls", "frame_rx1_controls", "frame_rx2_controls"};
+	char *ch_buttons[] = {"cb_tx_chan1_en", "cb_tx_chan2_en", "cb_rx_chan1_en", "cb_rx_chan2_en"};
 
 	for (i = 0; i < ARRAY_SIZE(ch_frames); i++) {
 		channel_frame = GTK_WIDGET(gtk_builder_get_object(priv->builder, ch_frames[i]));


### PR DESCRIPTION
The profile gen was failing to create a configuration since some attributes cannot be read if the channel is disabled