### PR TITLE
CI: github windows workflow:  change libads to main branch

### DIFF
--- a/.github/workflows/buildmingw.yml
+++ b/.github/workflows/buildmingw.yml
@@ -36,8 +36,8 @@ jobs:
                 -e HEAD_BRANCH=%GITHUB_HEAD_REF% ^
                 -e OSC_BUILD_VER=%TAG% ^
                 -e LIBIIO_BRANCH=libiio-v0 ^
-                -e LIBAD9361_BRANCH=master ^
-                -e LIBAD9166_BRANCH=master ^
+                -e LIBAD9361_BRANCH=main ^
+                -e LIBAD9166_BRANCH=main ^
                 shooteu/iio-oscilloscope C:\msys64\usr\bin\bash.exe -c '/home/docker/iio-oscilloscope/CI/docker/inside_docker.sh'
             
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
pull from main branches of libad9361 and libad9166 repos when building windows installer