### PR TITLE
dialogs.c: move the scanning process into its own thread.

### DIFF
--- a/dialogs.c
+++ b/dialogs.c
@@ -432,7 +432,8 @@ static struct iio_context * get_context(Dialogs *data)
 	}
 }
 
-static void refresh_usb(void)
+
+static void refresh_usb_thread(void)
 {
 	struct iio_scan_context *ctxs;
 	struct iio_context_info **info;
@@ -447,6 +448,7 @@ static void refresh_usb(void)
 	bool scan = false;
 	gchar *active_uri = NULL;
 
+	gdk_threads_enter();
 	widget_set_cursor(dialogs.connect, GDK_WATCH);
 
 	if (gtk_combo_box_get_active(GTK_COMBO_BOX(dialogs.connect_usbd)) != -1) {
@@ -565,6 +567,7 @@ nope:
 		gtk_widget_set_sensitive(dialogs.connect_usbd, false);
 		/* Force a clear */
 		connect_clear(dialogs.connect_net);
+		gdk_threads_leave();
 		return;
 	}
 
@@ -585,6 +588,14 @@ nope:
 
 	/* Fill things in */
 	connect_clear(dialogs.connect_usb);
+	gdk_threads_leave();
+
+}
+
+
+static void refresh_usb(void)
+{
+	g_thread_new("Scan thread", (void *) &refresh_usb_thread, NULL);
 }
 
 #ifdef SERIAL_BACKEND


### PR DESCRIPTION
## PR Description

On MacOS there were some issues with the network iio_context scanning process. Inside libiio, some mutex locks are done during scanning. This blocks the UI thread and makes the app unusable. Moving into its own thread and creating a protected section (similar to calibration processes) should resolve this issue.

Besides these changes, iio-osc also needs some different fixes to get it working on MacOS (here are 2 dev branches on this matter by Cristina and Travis).

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
