### PR TITLE
Support for v2 of tdd driver

### DIFF
--- a/glade/cf_axi_tdd_v2.glade
+++ b/glade/cf_axi_tdd_v2.glade
@@ -1,0 +1,1436 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment10">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment11">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment12">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment13">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment14">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment15">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment16">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment17">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment18">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment19">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment20">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment21">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment22">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment23">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment24">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment25">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment26">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment27">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment3">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment4">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment5">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment6">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment7">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment8">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment9">
+    <property name="upper">10000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkVBox" id="cf_axi_tdd_panel_v2">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="hexpand">True</property>
+    <property name="vexpand">True</property>
+    <child>
+      <object class="GtkScrolledWindow" id="scrolledwindow1">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <child>
+          <object class="GtkViewport" id="viewport1">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkVBox" id="vbox2">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkFrame" id="frame1">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkAlignment" id="global_settings">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
+                        <child>
+                          <object class="GtkVBox" id="boxGlobalSettings">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <child>
+                              <object class="GtkHBox" id="hbox3">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkFrame" id="frame5">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label-xalign">0</property>
+                                    <property name="shadow-type">in</property>
+                                    <child>
+                                      <object class="GtkAlignment" id="alignment4">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="left-padding">12</property>
+                                        <child>
+                                          <object class="GtkTable" id="table4">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="n-rows">3</property>
+                                            <property name="n-columns">2</property>
+                                            <child>
+                                              <object class="GtkLabel" id="label15">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">External Sync</property>
+                                                <property name="yalign">0.47999998927116394</property>
+                                              </object>
+                                              <packing>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="global_enable">
+                                                <property name="label" translatable="yes">
+</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="draw-indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="right-attach">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="external_sync_enable">
+                                                <property name="label" translatable="yes">
+</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="draw-indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="right-attach">2</property>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label3">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">&lt;b&gt;Enable TDD&lt;/b&gt;</property>
+                                                <property name="use-markup">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label24">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Internal Sync</property>
+                                                <property name="yalign">0.47999998927116394</property>
+                                              </object>
+                                              <packing>
+                                                <property name="top-attach">2</property>
+                                                <property name="bottom-attach">3</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkCheckButton" id="internal_sync_enable">
+                                                <property name="label" translatable="yes">
+</property>
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="receives-default">False</property>
+                                                <property name="draw-indicator">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="right-attach">2</property>
+                                                <property name="top-attach">2</property>
+                                                <property name="bottom-attach">3</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child type="label_item">
+                                      <placeholder/>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkFrame" id="frame8">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label-xalign">0</property>
+                                    <property name="shadow-type">in</property>
+                                    <child>
+                                      <object class="GtkAlignment" id="alignment6">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="left-padding">12</property>
+                                        <child>
+                                          <object class="GtkTable" id="table6">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="n-rows">3</property>
+                                            <property name="n-columns">2</property>
+                                            <child>
+                                              <object class="GtkSpinButton" id="burst_count">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="invisible-char">●</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment1</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="right-attach">2</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label4">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Frame Length (ms)</property>
+                                                <property name="yalign">0.47999998927116394</property>
+                                              </object>
+                                              <packing>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="frame_length">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="invisible-char">●</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment2</property>
+                                                <property name="digits">6</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="right-attach">2</property>
+                                                <property name="top-attach">1</property>
+                                                <property name="bottom-attach">2</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label1">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Burst Count</property>
+                                              </object>
+                                              <packing>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkLabel" id="label2">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">False</property>
+                                                <property name="label" translatable="yes">Start-up Delay (ms)</property>
+                                                <property name="yalign">0.47999998927116394</property>
+                                              </object>
+                                              <packing>
+                                                <property name="top-attach">2</property>
+                                                <property name="bottom-attach">3</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkSpinButton" id="startup_delay">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="invisible-char">●</property>
+                                                <property name="text" translatable="yes">0</property>
+                                                <property name="primary-icon-activatable">False</property>
+                                                <property name="secondary-icon-activatable">False</property>
+                                                <property name="adjustment">adjustment9</property>
+                                                <property name="digits">6</property>
+                                              </object>
+                                              <packing>
+                                                <property name="left-attach">1</property>
+                                                <property name="right-attach">2</property>
+                                                <property name="top-attach">2</property>
+                                                <property name="bottom-attach">3</property>
+                                                <property name="x-options">GTK_FILL</property>
+                                                <property name="y-options">GTK_FILL</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child type="label_item">
+                                      <placeholder/>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkHBox" id="box7">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_global_settings">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">&lt;b&gt;TDD Global Settings&lt;/b&gt;</property>
+                            <property name="use-markup">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="channel_frame">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkAlignment" id="channel_setting">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="left-padding">12</property>
+                        <child>
+                          <object class="GtkHBox" id="hbox1">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <child>
+                              <object class="GtkFrame" id="frame3">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <property name="shadow-type">in</property>
+                                <child>
+                                  <object class="GtkAlignment" id="alignment1">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <child>
+                                      <object class="GtkTable" id="table1">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="n-rows">4</property>
+                                        <property name="n-columns">2</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label9">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">On (ms)</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="channel0_on">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="invisible-char">●</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment3</property>
+                                            <property name="digits">6</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="channel0_off">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="invisible-char">●</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment6</property>
+                                            <property name="digits">6</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="label10">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Off (ms)</property>
+                                          </object>
+                                          <packing>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">&lt;b&gt;Enable &lt;/b&gt;</property>
+                                            <property name="use-markup">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="top-attach">3</property>
+                                            <property name="bottom-attach">4</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="channel0_enable">
+                                            <property name="label" translatable="yes">
+</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">3</property>
+                                            <property name="bottom-attach">4</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Inverted Polarity</property>
+                                          </object>
+                                          <packing>
+                                            <property name="top-attach">2</property>
+                                            <property name="bottom-attach">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="channel0_polarity">
+                                            <property name="label" translatable="yes">
+</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">2</property>
+                                            <property name="bottom-attach">3</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="label7">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">&lt;b&gt;Channel 0&lt;/b&gt;</property>
+                                    <property name="use-markup">True</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="frame4">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <property name="shadow-type">in</property>
+                                <child>
+                                  <object class="GtkAlignment" id="alignment2">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <child>
+                                      <object class="GtkTable" id="table2">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="n-rows">4</property>
+                                        <property name="n-columns">2</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label6">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">On (ms)</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="channel1_on">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="invisible-char">●</property>
+                                            <property name="text" translatable="yes">0</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment4</property>
+                                            <property name="digits">6</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="channel1_off">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="invisible-char">●</property>
+                                            <property name="text" translatable="yes">0</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment7</property>
+                                            <property name="digits">6</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="label8">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Off (ms)</property>
+                                          </object>
+                                          <packing>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">&lt;b&gt; Enable &lt;/b&gt;</property>
+                                            <property name="use-markup">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="top-attach">3</property>
+                                            <property name="bottom-attach">4</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="channel1_enable">
+                                            <property name="label" translatable="yes">
+</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">3</property>
+                                            <property name="bottom-attach">4</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Inverted Polarity</property>
+                                          </object>
+                                          <packing>
+                                            <property name="top-attach">2</property>
+                                            <property name="bottom-attach">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="channel1_polarity">
+                                            <property name="label" translatable="yes">
+</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">2</property>
+                                            <property name="bottom-attach">3</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="label11">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">&lt;b&gt;Channel 1&lt;/b&gt;</property>
+                                    <property name="use-markup">True</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkFrame" id="frame6">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label-xalign">0</property>
+                                <property name="shadow-type">in</property>
+                                <child>
+                                  <object class="GtkAlignment" id="alignment3">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="left-padding">12</property>
+                                    <child>
+                                      <object class="GtkTable" id="table3">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="n-rows">4</property>
+                                        <property name="n-columns">2</property>
+                                        <child>
+                                          <object class="GtkLabel" id="label12">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">On (ms)</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="channel2_on">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="invisible-char">●</property>
+                                            <property name="text" translatable="yes">0</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment5</property>
+                                            <property name="digits">6</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkSpinButton" id="channel2_off">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="invisible-char">●</property>
+                                            <property name="text" translatable="yes">0</property>
+                                            <property name="primary-icon-activatable">False</property>
+                                            <property name="secondary-icon-activatable">False</property>
+                                            <property name="adjustment">adjustment8</property>
+                                            <property name="digits">6</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="label13">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Off (ms)</property>
+                                          </object>
+                                          <packing>
+                                            <property name="top-attach">1</property>
+                                            <property name="bottom-attach">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">&lt;b&gt; Enable &lt;/b&gt;</property>
+                                            <property name="use-markup">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="top-attach">3</property>
+                                            <property name="bottom-attach">4</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="channel2_enable">
+                                            <property name="label" translatable="yes">
+</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">3</property>
+                                            <property name="bottom-attach">4</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="label" translatable="yes">Inverted Polarity</property>
+                                          </object>
+                                          <packing>
+                                            <property name="top-attach">2</property>
+                                            <property name="bottom-attach">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="channel2_polarity">
+                                            <property name="label" translatable="yes">
+</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">1</property>
+                                            <property name="right-attach">2</property>
+                                            <property name="top-attach">2</property>
+                                            <property name="bottom-attach">3</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="label14">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">&lt;b&gt;Channel 2&lt;/b&gt;</property>
+                                    <property name="use-markup">True</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkHBox" id="box1">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="channel_settings">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Channel Settings&lt;/b&gt;</property>
+                            <property name="use-markup">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkAlignment" id="channel_setting1">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="left-padding">12</property>
+                    <child>
+                      <object class="GtkHBox" id="hbox2">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <object class="GtkFrame" id="frame2">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label-xalign">0</property>
+                            <property name="shadow-type">in</property>
+                            <child>
+                              <object class="GtkAlignment" id="alignment5">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
+                                <child>
+                                  <object class="GtkTable" id="table5">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">4</property>
+                                    <property name="n-columns">2</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label5">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">On (ms)</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="channel3_on">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="invisible-char">●</property>
+                                        <property name="text" translatable="yes">0.000000</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
+                                        <property name="adjustment">adjustment3</property>
+                                        <property name="digits">6</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="channel3_off">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="invisible-char">●</property>
+                                        <property name="text" translatable="yes">0.000000</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
+                                        <property name="adjustment">adjustment6</property>
+                                        <property name="digits">6</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label16">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Off (ms)</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">&lt;b&gt;Enable &lt;/b&gt;</property>
+                                        <property name="use-markup">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="channel3_enable">
+                                        <property name="label" translatable="yes">
+</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Inverted Polarity</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="channel3_polarity">
+                                        <property name="label" translatable="yes">
+</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel" id="label17">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">&lt;b&gt;Channel 3&lt;/b&gt;</property>
+                                <property name="use-markup">True</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFrame" id="frame7">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label-xalign">0</property>
+                            <property name="shadow-type">in</property>
+                            <child>
+                              <object class="GtkAlignment" id="alignment7">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
+                                <child>
+                                  <object class="GtkTable" id="table7">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">4</property>
+                                    <property name="n-columns">2</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label18">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">On (ms)</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="channel4_on">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="invisible-char">●</property>
+                                        <property name="text" translatable="yes">0.000000</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
+                                        <property name="adjustment">adjustment4</property>
+                                        <property name="digits">6</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="channel4_off">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="invisible-char">●</property>
+                                        <property name="text" translatable="yes">0.000000</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
+                                        <property name="adjustment">adjustment7</property>
+                                        <property name="digits">6</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label19">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Off (ms)</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">&lt;b&gt; Enable &lt;/b&gt;</property>
+                                        <property name="use-markup">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="channel4_enable">
+                                        <property name="label" translatable="yes">
+</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Inverted Polarity</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="channel4_polarity">
+                                        <property name="label" translatable="yes">
+</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel" id="label20">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">&lt;b&gt;Channel 4&lt;/b&gt;</property>
+                                <property name="use-markup">True</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFrame" id="frame9">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label-xalign">0</property>
+                            <property name="shadow-type">in</property>
+                            <child>
+                              <object class="GtkAlignment" id="alignment8">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="left-padding">12</property>
+                                <child>
+                                  <object class="GtkTable" id="table8">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="n-rows">4</property>
+                                    <property name="n-columns">2</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label21">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">On (ms)</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="channel5_on">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="invisible-char">●</property>
+                                        <property name="text" translatable="yes">0.000000</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
+                                        <property name="adjustment">adjustment5</property>
+                                        <property name="digits">6</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="channel5_off">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="invisible-char">●</property>
+                                        <property name="text" translatable="yes">0.000000</property>
+                                        <property name="primary-icon-activatable">False</property>
+                                        <property name="secondary-icon-activatable">False</property>
+                                        <property name="adjustment">adjustment8</property>
+                                        <property name="digits">6</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label22">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Off (ms)</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top-attach">1</property>
+                                        <property name="bottom-attach">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">&lt;b&gt; Enable &lt;/b&gt;</property>
+                                        <property name="use-markup">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="channel5_enable">
+                                        <property name="label" translatable="yes">
+</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="bottom-attach">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">Inverted Polarity</property>
+                                      </object>
+                                      <packing>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="channel5_polarity">
+                                        <property name="label" translatable="yes">
+</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="draw-indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">1</property>
+                                        <property name="right-attach">2</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="bottom-attach">3</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel" id="label23">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">&lt;b&gt;Channel 5&lt;/b&gt;</property>
+                                <property name="use-markup">True</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkHButtonBox" id="buttonbox1">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="spacing">15</property>
+        <property name="layout-style">center</property>
+        <child>
+          <object class="GtkButton" id="settings_reload">
+            <property name="label">Reload Settings</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="pack-type">end</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </object>
+  <object class="GtkListStore" id="liststore1">
+    <columns>
+      <!-- column-name polarity -->
+      <column type="gint"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0">0</col>
+      </row>
+      <row>
+        <col id="0">1</col>
+      </row>
+    </data>
+  </object>
+</interface>

--- a/glade/cf_axi_tdd_v2.glade
+++ b/glade/cf_axi_tdd_v2.glade
@@ -59,7 +59,7 @@
   </object>
   <object class="GtkAdjustment" id="adjustment2">
     <property name="upper">10000</property>
-    <property name="step-increment">1</property>
+    <property name="step-increment">9.9999999999999995e-07</property>
     <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment20">
@@ -104,7 +104,7 @@
   </object>
   <object class="GtkAdjustment" id="adjustment3">
     <property name="upper">10000</property>
-    <property name="step-increment">1</property>
+    <property name="step-increment">9.9999999999999995e-07</property>
     <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment4">
@@ -134,7 +134,7 @@
   </object>
   <object class="GtkAdjustment" id="adjustment9">
     <property name="upper">10000</property>
-    <property name="step-increment">1</property>
+    <property name="step-increment">9.9999999999999995e-07</property>
     <property name="page-increment">10</property>
   </object>
   <object class="GtkVBox" id="cf_axi_tdd_panel_v2">
@@ -974,7 +974,7 @@
                                         <property name="text" translatable="yes">0.000000</property>
                                         <property name="primary-icon-activatable">False</property>
                                         <property name="secondary-icon-activatable">False</property>
-                                        <property name="adjustment">adjustment3</property>
+                                        <property name="adjustment">adjustment15</property>
                                         <property name="digits">6</property>
                                       </object>
                                       <packing>
@@ -990,7 +990,7 @@
                                         <property name="text" translatable="yes">0.000000</property>
                                         <property name="primary-icon-activatable">False</property>
                                         <property name="secondary-icon-activatable">False</property>
-                                        <property name="adjustment">adjustment6</property>
+                                        <property name="adjustment">adjustment12</property>
                                         <property name="digits">6</property>
                                       </object>
                                       <packing>
@@ -1117,7 +1117,7 @@
                                         <property name="text" translatable="yes">0.000000</property>
                                         <property name="primary-icon-activatable">False</property>
                                         <property name="secondary-icon-activatable">False</property>
-                                        <property name="adjustment">adjustment4</property>
+                                        <property name="adjustment">adjustment10</property>
                                         <property name="digits">6</property>
                                       </object>
                                       <packing>
@@ -1133,7 +1133,7 @@
                                         <property name="text" translatable="yes">0.000000</property>
                                         <property name="primary-icon-activatable">False</property>
                                         <property name="secondary-icon-activatable">False</property>
-                                        <property name="adjustment">adjustment7</property>
+                                        <property name="adjustment">adjustment13</property>
                                         <property name="digits">6</property>
                                       </object>
                                       <packing>
@@ -1260,7 +1260,7 @@
                                         <property name="text" translatable="yes">0.000000</property>
                                         <property name="primary-icon-activatable">False</property>
                                         <property name="secondary-icon-activatable">False</property>
-                                        <property name="adjustment">adjustment5</property>
+                                        <property name="adjustment">adjustment11</property>
                                         <property name="digits">6</property>
                                       </object>
                                       <packing>
@@ -1276,7 +1276,7 @@
                                         <property name="text" translatable="yes">0.000000</property>
                                         <property name="primary-icon-activatable">False</property>
                                         <property name="secondary-icon-activatable">False</property>
-                                        <property name="adjustment">adjustment8</property>
+                                        <property name="adjustment">adjustment14</property>
                                         <property name="digits">6</property>
                                       </object>
                                       <packing>

--- a/plugins/cf_axi_tdd.c
+++ b/plugins/cf_axi_tdd.c
@@ -54,17 +54,33 @@ static void reload_settings(GtkButton *btn, struct plugin_private *priv)
 	iio_update_widgets_block_signals_by_data(priv->w, priv->n_w);
 }
 
-static int cf_axi_tdd_chann_widgets_init(struct plugin_private *priv, struct iio_device *dev)
+static int cf_axi_tdd_v1_widgets_init(struct plugin_private *priv, struct iio_device *dev)
 {
 	const unsigned int n_channels = iio_device_get_channels_count(dev);
 	struct iio_channel *chan;
 	unsigned int i;
 	char widget_str[32];
+	GtkWidget *global, *primary, *secondary;
+	GtkToggleToolButton *global_btn, *primary_btn, *secondary_btn;
 
 	if (!n_channels) {
 		printf("Could not find any iio channel\n");
 		return -ENODEV;
 	}
+
+	iio_spin_button_int_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "counter_int",
+		priv->builder, "counter_int", NULL);
+	iio_combo_box_init_no_avail_flush_from_builder(&priv->w[priv->n_w++], dev, NULL,"dma_gateing_mode",
+		"dma_gateing_mode_available", priv->builder,
+		"dma_gateing_mode", NULL);
+	iio_combo_box_init_no_avail_flush_from_builder(&priv->w[priv->n_w++], dev, NULL, "en_mode",
+		"en_mode_available", priv->builder, "enable_mode", NULL);
+	iio_toggle_button_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "sync_terminal_type",
+		priv->builder, "sync_terminal_type", false);
+	iio_toggle_button_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "en", priv->builder,
+		"enable", false);
+	iio_toggle_button_init_from_builder(&priv->secondary, dev, NULL, "secondary", priv->builder,
+						"secondary_frame", false);
 
 	for (i = 0; i < n_channels; i++) {
 		chan = iio_device_get_channel(dev, i);
@@ -97,6 +113,32 @@ static int cf_axi_tdd_chann_widgets_init(struct plugin_private *priv, struct iio
 						      "vco_off_ms", priv->builder, widget_str, NULL);
 	}
 
+	/* handle sections buttons and reload settings */
+	global = GTK_WIDGET(gtk_builder_get_object(priv->builder, "global_settings"));
+	global_btn = GTK_TOGGLE_TOOL_BUTTON(gtk_builder_get_object(priv->builder,
+						"global_settings_toggle"));
+	primary = GTK_WIDGET(gtk_builder_get_object(priv->builder, "tdd_primary"));
+	primary_btn = GTK_TOGGLE_TOOL_BUTTON(gtk_builder_get_object(priv->builder,
+						"tdd_primary_toggle"));
+	secondary = GTK_WIDGET(gtk_builder_get_object(priv->builder, "tdd_secondary"));
+	secondary_btn = GTK_TOGGLE_TOOL_BUTTON(gtk_builder_get_object(priv->builder,
+						"tdd_secondary_toggle"));
+	priv->secondary_frame = GTK_WIDGET(gtk_builder_get_object(priv->builder,
+						"tdd_secondary_frame"));
+
+	g_signal_connect(G_OBJECT(global_btn), "clicked", G_CALLBACK(handle_toggle_section_cb),
+			global);
+	g_signal_connect(G_OBJECT(primary_btn), "clicked", G_CALLBACK(handle_toggle_section_cb),
+			primary);
+	g_signal_connect(G_OBJECT(secondary_btn), "clicked", G_CALLBACK(handle_toggle_section_cb),
+			secondary);
+
+	iio_update_widgets(priv->w, priv->n_w);
+	iio_widget_update(&priv->secondary);
+	if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->secondary.widget)))
+		gtk_widget_set_sensitive(priv->secondary_frame, false);
+	iio_make_widget_update_signal_based(&priv->secondary, G_CALLBACK(save_secondary), priv);
+
 	return 0;
 }
 
@@ -106,13 +148,8 @@ static int cf_axi_tdd_v2_widgets_init(struct plugin_private *priv, struct iio_de
 	struct iio_channel *chan;
 	unsigned int i;
 	char widget_str[32];
-	GtkButton *reload_btn;
 
-	iio_spin_button_int_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "burst_count",
-		priv->builder, "burst_count", NULL);
-	iio_spin_button_int_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "frame_length_ms",
-		priv->builder, "frame_length", NULL);
-	iio_spin_button_int_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "startup_delay_ms",
+	iio_spin_button_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "startup_delay_ms",
 		priv->builder, "startup_delay", NULL);
 	iio_toggle_button_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "enable",
 		priv->builder, "global_enable", false);
@@ -132,10 +169,10 @@ static int cf_axi_tdd_v2_widgets_init(struct plugin_private *priv, struct iio_de
 			return -ENODEV;
 
 		sprintf(widget_str, "%s_on", iio_channel_get_id(chan));
-		iio_spin_button_int_init_from_builder(&priv->w[priv->n_w++], dev, chan,
+		iio_spin_button_init_from_builder(&priv->w[priv->n_w++], dev, chan,
 						      "on_ms", priv->builder, widget_str, NULL);
 		sprintf(widget_str, "%s_off", iio_channel_get_id(chan));
-		iio_spin_button_int_init_from_builder(&priv->w[priv->n_w++], dev, chan,
+		iio_spin_button_init_from_builder(&priv->w[priv->n_w++], dev, chan,
 						      "off_ms", priv->builder, widget_str, NULL);
 		sprintf(widget_str, "%s_polarity", iio_channel_get_id(chan));
 		iio_toggle_button_init_from_builder(&priv->w[priv->n_w++], dev, chan,
@@ -144,13 +181,6 @@ static int cf_axi_tdd_v2_widgets_init(struct plugin_private *priv, struct iio_de
 		iio_toggle_button_init_from_builder(&priv->w[priv->n_w++], dev, chan,
 						      "enable", priv->builder, widget_str, false);
 	}
-
-	reload_btn = GTK_BUTTON(gtk_builder_get_object(priv->builder, "settings_reload"));
-	g_signal_connect(G_OBJECT(reload_btn), "clicked", G_CALLBACK(reload_settings),
-			     priv);
-	iio_update_widgets(priv->w, priv->n_w);
-	iio_make_widgets_update_signal_based(priv->w, priv->n_w,
-						 G_CALLBACK(iio_widget_save_block_signals_by_data_cb));
 
 	return 0;
 }
@@ -162,8 +192,6 @@ static GtkWidget *cf_axi_tdd_init(struct osc_plugin *plugin, GtkWidget *notebook
 	struct plugin_private *priv = plugin->priv;
 	struct iio_device *dev;
 	const char *dev_name = g_list_first(priv->plugin_ctx.required_devices)->data;
-	GtkWidget *global, *primary, *secondary;
-	GtkToggleToolButton *global_btn, *primary_btn, *secondary_btn;
 	GtkButton *reload_btn;
 	int ret;
 
@@ -183,89 +211,43 @@ static GtkWidget *cf_axi_tdd_init(struct osc_plugin *plugin, GtkWidget *notebook
 	 * if the attribute is not found , load the previous version of the tdd plugin */
 
 	if(!iio_device_find_attr(dev, "version")) {
-	    if (osc_load_glade_file(priv->builder, "cf_axi_tdd") < 0)
-	      goto context_destroy;
+		if (osc_load_glade_file(priv->builder, "cf_axi_tdd") < 0)
+			goto context_destroy;
 
-	    cf_axi_tdd_panel = GTK_WIDGET(gtk_builder_get_object(priv->builder, "cf_axi_tdd_panel"));
-	    if (!cf_axi_tdd_panel)
-	      goto context_destroy;
+		cf_axi_tdd_panel = GTK_WIDGET(gtk_builder_get_object(priv->builder, "cf_axi_tdd_panel"));
+		if (!cf_axi_tdd_panel)
+			goto context_destroy;
 
-	    /* init device widgets */
-	    iio_spin_button_int_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "burst_count",
-		priv->builder, "burst_count", NULL);
-	    iio_spin_button_int_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "frame_length_ms",
-		priv->builder, "frame_length", NULL);
-	    iio_spin_button_int_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "counter_int",
-		priv->builder, "counter_int", NULL);
-	    iio_combo_box_init_no_avail_flush_from_builder(&priv->w[priv->n_w++], dev, NULL,"dma_gateing_mode",
-		"dma_gateing_mode_available", priv->builder,
-		"dma_gateing_mode", NULL);
-	    iio_combo_box_init_no_avail_flush_from_builder(&priv->w[priv->n_w++], dev, NULL, "en_mode",
-		"en_mode_available", priv->builder, "enable_mode", NULL);
-	    iio_toggle_button_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "sync_terminal_type",
-		priv->builder, "sync_terminal_type", false);
-	    iio_toggle_button_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "en", priv->builder,
-		"enable", false);
-	    iio_toggle_button_init_from_builder(&priv->secondary, dev, NULL, "secondary", priv->builder,
-						"secondary_frame", false);
-	    /* init channel widgets */
-	    ret = cf_axi_tdd_chann_widgets_init(priv, dev);
-	    if (ret)
-	      goto context_destroy;
-
-	    /* handle sections buttons and reload settings */
-	    global = GTK_WIDGET(gtk_builder_get_object(priv->builder, "global_settings"));
-	    global_btn = GTK_TOGGLE_TOOL_BUTTON(gtk_builder_get_object(priv->builder,
-								       "global_settings_toggle"));
-	    primary = GTK_WIDGET(gtk_builder_get_object(priv->builder, "tdd_primary"));
-	    primary_btn = GTK_TOGGLE_TOOL_BUTTON(gtk_builder_get_object(priv->builder,
-									"tdd_primary_toggle"));
-	    secondary = GTK_WIDGET(gtk_builder_get_object(priv->builder, "tdd_secondary"));
-	    secondary_btn = GTK_TOGGLE_TOOL_BUTTON(gtk_builder_get_object(priv->builder,
-									  "tdd_secondary_toggle"));
-
-	    reload_btn = GTK_BUTTON(gtk_builder_get_object(priv->builder, "settings_reload"));
-	    priv->secondary_frame = GTK_WIDGET(gtk_builder_get_object(priv->builder,
-								      "tdd_secondary_frame"));
-
-	    g_signal_connect(G_OBJECT(global_btn), "clicked", G_CALLBACK(handle_toggle_section_cb),
-			     global);
-	    g_signal_connect(G_OBJECT(primary_btn), "clicked", G_CALLBACK(handle_toggle_section_cb),
-			     primary);
-	    g_signal_connect(G_OBJECT(secondary_btn), "clicked", G_CALLBACK(handle_toggle_section_cb),
-			     secondary);
-	    g_signal_connect(G_OBJECT(reload_btn), "clicked", G_CALLBACK(reload_settings),
-			     priv);
-
-	    iio_update_widgets(priv->w, priv->n_w);
-	    iio_widget_update(&priv->secondary);
-	    if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->secondary.widget)))
-	      gtk_widget_set_sensitive(priv->secondary_frame, false);
-
-	    iio_make_widgets_update_signal_based(priv->w, priv->n_w,
-						 G_CALLBACK(iio_widget_save_block_signals_by_data_cb));
-	    iio_make_widget_update_signal_based(&priv->secondary, G_CALLBACK(save_secondary), priv);
-
-	    return cf_axi_tdd_panel;
+		/* init channel widgets */
+		ret = cf_axi_tdd_v1_widgets_init(priv, dev);
+		if (ret)
+			goto context_destroy;
 	}
 	else {
+		if (osc_load_glade_file(priv->builder, "cf_axi_tdd_v2") < 0)
+			goto context_destroy;
 
-	    if (osc_load_glade_file(priv->builder, "cf_axi_tdd_v2") < 0)
-	      goto context_destroy;
+		cf_axi_tdd_panel = GTK_WIDGET(gtk_builder_get_object(priv->builder, "cf_axi_tdd_panel_v2"));
+		if (!cf_axi_tdd_panel)
+			goto context_destroy;
+		/* init widgets */
 
-	    cf_axi_tdd_panel = GTK_WIDGET(gtk_builder_get_object(priv->builder, "cf_axi_tdd_panel_v2"));
-	    if (!cf_axi_tdd_panel)
-	      goto context_destroy;
-
-	    /* init widgets */
-
-	    ret = cf_axi_tdd_v2_widgets_init(priv, dev);
-	    if (ret)
-	      goto context_destroy;
-
-	    return cf_axi_tdd_panel;
-
-	  }
+		ret = cf_axi_tdd_v2_widgets_init(priv, dev);
+		if (ret)
+			goto context_destroy;
+	}
+	/* init common device widgets */
+	iio_spin_button_int_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "burst_count",
+		priv->builder, "burst_count", NULL);
+	iio_spin_button_init_from_builder(&priv->w[priv->n_w++], dev, NULL, "frame_length_ms",
+		priv->builder, "frame_length", NULL);
+	reload_btn = GTK_BUTTON(gtk_builder_get_object(priv->builder, "settings_reload"));
+	g_signal_connect(G_OBJECT(reload_btn), "clicked", G_CALLBACK(reload_settings),
+			     priv);
+	iio_update_widgets(priv->w, priv->n_w);
+	iio_make_widgets_update_signal_based(priv->w, priv->n_w,
+						 G_CALLBACK(iio_widget_save_block_signals_by_data_cb));
+	return cf_axi_tdd_panel;
 
 context_destroy:
 	osc_destroy_context(priv->ctx);


### PR DESCRIPTION
## PR Description

A new version of the tdd driver will be released soon. This ensures support for both versions of the driver. This is done by checking for the version attribute, which only exists in v2 of the driver. If said attribute is found, osc will load the newly added glade file, with widgets corresponding to the new attribute. If the version attribute is not found, osc will load the old plugin. 

Note: this is still under development and will be updated if the requirements/ functionality would change. 

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
