### PR TITLE
adrv9002: API version mismatch fix

### DIFF
--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -2263,6 +2263,25 @@ static char *profile_gen_cli_get_api(void)
 	return version;
 }
 
+static char *strip_leading_and_trailing_nonnumeric_chars(char *string)
+{
+	int i;
+	char *str = (char *)malloc(strlen(string) * sizeof(char));
+	sprintf(str, "%s", string);
+
+	while((str[0] < '0' || str[0] > '9') && str[0] != '\0') {
+		str++;
+	}
+
+	i = strlen(str) - 1;
+	while((str[i] < '0' || str[i] > '9') && i > 0) {
+		str[i] = '\0';
+		i--;
+	}
+
+	return str;
+}
+
 static bool profile_gen_check_api(gpointer data)
 {
 	struct plugin_private *priv = data;
@@ -2281,7 +2300,8 @@ static bool profile_gen_check_api(gpointer data)
 		goto err;
 	}
 
-	if(strcmp(version, supported_version) != 0) {
+	if(strcmp(strip_leading_and_trailing_nonnumeric_chars(supported_version),
+		  strip_leading_and_trailing_nonnumeric_chars(version)) != 0) {
 		sprintf(message, "\nOnly API version %s is supported, the device uses %s!", supported_version, version);
 		profile_gen_set_debug_info(data, message);
 		free(supported_version);

--- a/plugins/adrv9002.c
+++ b/plugins/adrv9002.c
@@ -2302,10 +2302,23 @@ static bool profile_gen_check_api(gpointer data)
 
 	if(strcmp(strip_leading_and_trailing_nonnumeric_chars(supported_version),
 		  strip_leading_and_trailing_nonnumeric_chars(version)) != 0) {
-		sprintf(message, "\nOnly API version %s is supported, the device uses %s!", supported_version, version);
-		profile_gen_set_debug_info(data, message);
-		free(supported_version);
-		goto err;
+		sprintf(message,
+			"\nDriver API - Profile generator API version mismatch\nDriver (%s)"
+			"\nProfile Generator (%s)",
+			supported_version, version);
+		GtkWidget *adrv9002_panel = GTK_WIDGET(gtk_builder_get_object(priv->builder, "adrv9002_panel"));
+		GtkWidget *dialog = gtk_message_dialog_new(
+					GTK_WINDOW(gtk_widget_get_toplevel(adrv9002_panel)),
+					GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_WARNING, GTK_BUTTONS_YES_NO,
+					"%s\n\nAre you sure you want to load the profile?", message);
+		gint response = gtk_dialog_run(GTK_DIALOG(dialog));
+		gtk_widget_destroy(dialog);
+
+		if(response != GTK_RESPONSE_YES) {
+			profile_gen_set_debug_info(data, message);
+			free(supported_version);
+			goto err;
+		}
 	}
 
 	free(supported_version);


### PR DESCRIPTION
## PR Description

- validation failed if driver was "68.8.1" and profile gen was "v68.8.1", so we now check if they contain the same version substring
- added option to load profile even with API version mismatch

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
