### PR TITLE
fix compile errors related to use of calloc and malloc

### DIFF
--- a/libini2.c
+++ b/libini2.c
@@ -469,7 +469,7 @@ static struct ini_loop * ini_loop_new(char *buf_with_loop, char *loop_name)
 	}
 
 	/* Store all necessary parameters of a loop */
-	loop = calloc(sizeof(struct ini_loop), 1);
+	loop = calloc(1, sizeof(struct ini_loop));
 	if (!loop) {
 		fprintf(stderr, "%s is %s", strerror(errno), __func__);
 		goto err_close;

--- a/oscplot.c
+++ b/oscplot.c
@@ -1886,7 +1886,7 @@ static PlotIioChn * plot_iio_channel_new(struct iio_context *ctx)
 {
 	PlotIioChn *obj;
 
-	obj = calloc(sizeof(PlotIioChn), 1);
+	obj = calloc(1, sizeof(PlotIioChn));
 	if (!obj) {
 		fprintf(stderr, "Error in %s: %s", __func__, strerror(errno));
 		return NULL;
@@ -1969,7 +1969,7 @@ static PlotMathChn * plot_math_channel_new(struct iio_context *ctx)
 {
 	PlotMathChn *obj;
 
-	obj = calloc(sizeof(PlotMathChn), 1);
+	obj = calloc(1, sizeof(PlotMathChn));
 	if (!obj) {
 		fprintf(stderr, "Error in %s: %s", __func__, strerror(errno));
 		return NULL;
@@ -2467,7 +2467,7 @@ static void update_transform_settings(OscPlot *plot, Transform *transform)
 		XCORR_SETTINGS(transform)->marker_type = NULL;
 		XCORR_SETTINGS(transform)->max_x_axis = gtk_spin_button_get_value(GTK_SPIN_BUTTON(priv->sample_count_widget));
 	} else if (plot_type == SPECTRUM_PLOT) {
-		FREQ_SPECTRUM_SETTINGS(transform)->ffts_alg_data = calloc(sizeof(struct _fft_alg_data), priv->fft_count);
+		FREQ_SPECTRUM_SETTINGS(transform)->ffts_alg_data = calloc(priv->fft_count, sizeof(struct _fft_alg_data));
 		FREQ_SPECTRUM_SETTINGS(transform)->fft_count = priv->fft_count;
 		FREQ_SPECTRUM_SETTINGS(transform)->freq_sweep_start = priv->start_freq + priv->filter_bw / 2;
 		FREQ_SPECTRUM_SETTINGS(transform)->filter_bandwidth = priv->filter_bw;
@@ -2513,33 +2513,33 @@ static Transform* add_transform_to_list(OscPlot *plot, int tr_type, GSList *chan
 	switch (tr_type) {
 	case TIME_TRANSFORM:
 		Transform_attach_function(transform, time_transform_function);
-		time_settings = (struct _time_settings *)calloc(sizeof(struct _time_settings), 1);
+		time_settings = (struct _time_settings *)calloc(1, sizeof(struct _time_settings));
 		Transform_attach_settings(transform, time_settings);
 		transform->graph_color = &PLOT_CHN(channels->data)->graph_color;
 		break;
 	case FFT_TRANSFORM:
 		Transform_attach_function(transform, fft_transform_function);
-		fft_settings = (struct _fft_settings *)calloc(sizeof(struct _fft_settings), 1);
+		fft_settings = (struct _fft_settings *)calloc(1, sizeof(struct _fft_settings));
 		Transform_attach_settings(transform, fft_settings);
 		break;
 	case CONSTELLATION_TRANSFORM:
 		Transform_attach_function(transform, constellation_transform_function);
-		constellation_settings = (struct _constellation_settings *)calloc(sizeof(struct _constellation_settings), 1);
+		constellation_settings = (struct _constellation_settings *)calloc(1, sizeof(struct _constellation_settings));
 		Transform_attach_settings(transform, constellation_settings);
 		break;
 	case COMPLEX_FFT_TRANSFORM:
 		Transform_attach_function(transform, fft_transform_function);
-		fft_settings = (struct _fft_settings *)calloc(sizeof(struct _fft_settings), 1);
+		fft_settings = (struct _fft_settings *)calloc(1, sizeof(struct _fft_settings));
 		Transform_attach_settings(transform, fft_settings);
 		break;
 	case CROSS_CORRELATION_TRANSFORM:
 		Transform_attach_function(transform, cross_correlation_transform_function);
-		xcross_settings = (struct _cross_correlation_settings *)calloc(sizeof(struct _cross_correlation_settings), 1);
+		xcross_settings = (struct _cross_correlation_settings *)calloc(1, sizeof(struct _cross_correlation_settings));
 		Transform_attach_settings(transform, xcross_settings);
 		break;
 	case FREQ_SPECTRUM_TRANSFORM:
 		Transform_attach_function(transform, freq_spectrum_transform_function);
-		freq_spectrum_settings = (struct _freq_spectrum_settings *)calloc(sizeof(struct _freq_spectrum_settings), 1);
+		freq_spectrum_settings = (struct _freq_spectrum_settings *)calloc(1, sizeof(struct _freq_spectrum_settings));
 		Transform_attach_settings(transform, freq_spectrum_settings);
 		break;
 	default:
@@ -2694,7 +2694,7 @@ static void transform_add_own_markers(OscPlot *plot, Transform *transform)
 	struct marker_type *markers;
 	int i;
 
-	markers = calloc(sizeof(struct marker_type), MAX_MARKERS + 2);
+	markers = calloc(MAX_MARKERS + 2, sizeof(struct marker_type));
 	if (!markers) {
 		fprintf(stderr,
 			"Error: could not alloc memory for markers in %s\n",

--- a/phone_home.c
+++ b/phone_home.c
@@ -202,7 +202,7 @@ fail:
 
 Release * release_new(void)
 {
-	return calloc(sizeof(Release), 1);
+	return calloc(1, sizeof(Release));
 }
 
 void release_dispose(Release *_this)

--- a/xml_utils.c
+++ b/xml_utils.c
@@ -7,6 +7,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <dirent.h>
 #include <string.h>
 #include <libxml/xmlmemory.h>


### PR DESCRIPTION
## PR Description

While compiling iio-oscilloscope from source on Fedora 40, I encountered numerous errors related to calloc arguments being backwards (i.e. size specified before member count), and one because malloc was used without `#include <stdlib.h>`. These two patches should fix that.

I'm not sure if/how this worked for older toolchains, so if this is an incorrect fix, please let me know and reject this.

## PR Type
- [X] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [X] I have followed the coding standards and guidelines
- [X] I have conducted a self-review of my own code changes
- [ ] I have checked in CI output that no new warnings/errors got introduced
