### PR TITLE
Fix Impulse Generator Menu

### DIFF
--- a/oscplot.c
+++ b/oscplot.c
@@ -6750,17 +6750,17 @@ static gboolean right_click_menu_show(OscPlot *plot, GdkEvent *event)
 		/* Check if device needs a trigger */
 		struct iio_device *dev = ref;
 		const struct iio_device *trigger;
-		bool has_trigger;
+		bool needs_trigger;
 		int ret;
 
 		ret = iio_device_get_trigger(dev, &trigger);
-		has_trigger = false;
-		if (ret == 0 && trigger) {
-			has_trigger = true;
+		needs_trigger = false;
+		if (ret == 0) {
+			needs_trigger = true;
 		}
 
 		gtk_widget_set_sensitive(priv->device_trigger_menuitem,
-				has_trigger);
+				needs_trigger);
 
 		gtk_menu_popup_at_pointer(GTK_MENU(priv->device_settings_menu), event);
 		return true;


### PR DESCRIPTION
## PR Description
iio_device_get_trigger will return 0 on success, but if there is no device assigned to the trigger, the trigger pointer will be NULL. since the impulse generator menu sets the trigger, the condition if (ret == 0 && trigger) will not be satisfied. this resulted in the impulse generator menu being grayed out. Now, we will only check that the return value is 0, to see if our device needs a trigger, which will be configured in the menu. The renaming of the bool variable to needs_trigger is to avoid confusion.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [x] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
