### PR TITLE
Libiio v1 support ad9361

### DIFF
--- a/iio_utils.c
+++ b/iio_utils.c
@@ -326,3 +326,24 @@ void dev_attr_read_all(struct iio_device *dev,
 		}
 	}
 }
+
+void chn_attr_read_all(struct iio_channel *chn,
+    int (*cb)(struct iio_channel *chn, const char *attr, const char *value, size_t len, void *d),
+    void *data)
+{
+	unsigned int i, attr_cnt = iio_channel_get_attrs_count(chn);
+	const struct iio_attr *attr;
+	char local_value[8192];
+	int ret;
+
+	for (i = 0; i < attr_cnt; ++i) {
+		attr = iio_channel_get_attr(chn, i);
+		ret = iio_attr_read_raw(attr, local_value, ARRAY_SIZE(local_value));
+		if (ret < 0) {
+			fprintf(stderr, "Failed to read attribute: %s\n", iio_attr_get_name(attr));
+			continue;
+		} else {
+			cb(chn, iio_attr_get_name(attr), local_value, strlen(local_value), data);
+		}
+	}
+}

--- a/iio_utils.c
+++ b/iio_utils.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <gtk/gtk.h>
+#include <errno.h>
 
 static gint iio_chn_cmp_by_name(gconstpointer ptr_a, gconstpointer ptr_b)
 {
@@ -161,4 +162,144 @@ bool iio_attr_not_found(struct iio_device *dev, struct iio_channel *chn, const c
 		return !iio_device_find_attr(dev, attr_name);
 
 	return !iio_channel_find_attr(chn, attr_name);
+}
+
+int dev_attr_read_raw(struct iio_device *dev, const char *attr_name, char *dst, size_t len)
+{
+	const struct iio_attr *attr = iio_device_find_attr(dev, attr_name);
+
+	if (attr)
+		return iio_attr_read_raw(attr, dst, len);
+	else
+		return -ENOENT;
+}
+
+int dev_attr_read_double(struct iio_device *dev, const char *attr_name, double *value)
+{
+	const struct iio_attr *attr = iio_device_find_attr(dev, attr_name);
+
+	if (attr)
+		return iio_attr_read_double(attr, value);
+	else
+		return -ENOENT;
+}
+
+int dev_attr_read_longlong(struct iio_device *dev, const char *attr_name, long long *value)
+{
+	const struct iio_attr *attr = iio_device_find_attr(dev, attr_name);
+
+	if (attr)
+		return iio_attr_read_longlong(attr, value);
+	else
+		return -ENOENT;
+}
+
+int dev_attr_write_double(struct iio_device *dev, const char *attr_name, double value)
+{
+	const struct iio_attr *attr = iio_device_find_attr(dev, attr_name);
+
+	if (attr)
+		return iio_attr_write_double(attr, value);
+	else
+		return -ENOENT;
+}
+
+int dev_attr_write_longlong(struct iio_device *dev, const char *attr_name, long long value)
+{
+	const struct iio_attr *attr = iio_device_find_attr(dev, attr_name);
+
+	if (attr)
+		return iio_attr_write_longlong(attr, value);
+	else
+		return -ENOENT;
+}
+
+int dev_debug_attr_write_longlong(struct iio_device *dev, const char *attr_name, long long value)
+{
+	const struct iio_attr *attr = iio_device_find_debug_attr(dev, attr_name);
+
+	if (attr)
+		return iio_attr_write_longlong(attr, value);
+	else
+		return -ENOENT;
+}
+
+int chn_attr_read_raw(struct iio_channel *chn, const char *attr_name, char *dst, size_t len)
+{
+	const struct iio_attr *attr = iio_channel_find_attr(chn, attr_name);
+
+	if (attr)
+		return iio_attr_read_raw(attr, dst, len);
+	else
+		return -ENOENT;
+}
+
+int chn_attr_read_bool(struct iio_channel *chn, const char *attr_name, bool *value)
+{
+	const struct iio_attr *attr = iio_channel_find_attr(chn, attr_name);
+
+	if (attr)
+		return iio_attr_read_bool(attr, value);
+	else
+		return -ENOENT;
+}
+
+int chn_attr_read_double(struct iio_channel *chn, const char *attr_name, double *value)
+{
+	const struct iio_attr *attr = iio_channel_find_attr(chn, attr_name);
+
+	if (attr)
+		return iio_attr_read_double(attr, value);
+	else
+		return -ENOENT;
+}
+
+int chn_attr_read_longlong(struct iio_channel *chn, const char *attr_name, long long *value)
+{
+	const struct iio_attr *attr = iio_channel_find_attr(chn, attr_name);
+
+	if (attr)
+		return iio_attr_read_longlong(attr, value);
+	else
+		return -ENOENT;
+}
+
+int chn_attr_write_string(struct iio_channel *chn, const char *attr_name, const char *string)
+{
+	const struct iio_attr *attr = iio_channel_find_attr(chn, attr_name);
+
+	if (attr)
+		return iio_attr_write_string(attr, string);
+	else
+		return -ENOENT;
+}
+
+int chn_attr_write_bool(struct iio_channel *chn, const char *attr_name, bool value)
+{
+	const struct iio_attr *attr = iio_channel_find_attr(chn, attr_name);
+
+	if (attr)
+		return iio_attr_write_bool(attr, value);
+	else
+		return -ENOENT;
+}
+
+int chn_attr_write_double(struct iio_channel *chn, const char *attr_name, double value)
+{
+	const struct iio_attr *attr = iio_channel_find_attr(chn, attr_name);
+
+	if (attr)
+		return iio_attr_write_double(attr, value);
+	else
+		return -ENOENT;
+}
+
+int chn_attr_write_longlong(struct iio_channel *chn, const char *attr_name, long long value)
+{
+	const struct iio_attr *attr = iio_channel_find_attr(chn, attr_name);
+
+	if (attr)
+		return iio_attr_write_longlong(attr, value);
+	else
+		return -ENOENT;
 }

--- a/iio_utils.h
+++ b/iio_utils.h
@@ -48,4 +48,9 @@ inline int chn_attr_write_bool(struct iio_channel *chn, const char *attr_name, b
 inline int chn_attr_write_double(struct iio_channel *chn, const char *attr_name, double value);
 inline int chn_attr_write_longlong(struct iio_channel *chn, const char *attr_name, long long value);
 
+/* Helpers to iterate through all attributes */
+inline void dev_attr_read_all(struct iio_device *dev,
+    int (*cb)(struct iio_device *dev, const char *attr, const char *value, size_t len, void *d),
+    void *data);
+
 #endif  /* __IIO_UTILS__ */

--- a/iio_utils.h
+++ b/iio_utils.h
@@ -26,4 +26,26 @@ void handle_toggle_section_cb(struct _GtkToggleToolButton *btn, struct _GtkWidge
 const char *get_iio_device_label_or_name(const struct iio_device *dev);
 bool iio_attr_not_found(struct iio_device *dev, struct iio_channel *chn, const char *attr_name);
 
+/* Helpers to read from iio attributes of devices */
+inline int dev_attr_read_raw(struct iio_device *dev, const char *attr_name, char *dst, size_t len);
+inline int dev_attr_read_double(struct iio_device *dev, const char *attr_name, double *value);
+inline int dev_attr_read_longlong(struct iio_device *dev, const char *attr_name, long long *value);
+
+/* Helpers to write to iio attributes of devices */
+inline int dev_attr_write_double(struct iio_device *dev, const char *attr_name, double value);
+inline int dev_attr_write_longlong(struct iio_device *dev, const char *attr_name, long long value);
+inline int dev_debug_attr_write_longlong(struct iio_device *dev, const char *attr_name, long long value);
+
+/* Helpers to read from iio attributes of channels */
+inline int chn_attr_read_raw(struct iio_channel *chn, const char *attr_name, char *dst, size_t len);
+inline int chn_attr_read_bool(struct iio_channel *chn, const char *attr_name, bool *value);
+inline int chn_attr_read_double(struct iio_channel *chn, const char *attr_name, double *value);
+inline int chn_attr_read_longlong(struct iio_channel *chn, const char *attr_name, long long *value);
+
+/* Helpers to write to iio attributes of channels */
+inline int chn_attr_write_string(struct iio_channel *chn, const char *attr_name, const char *string);
+inline int chn_attr_write_bool(struct iio_channel *chn, const char *attr_name, bool value);
+inline int chn_attr_write_double(struct iio_channel *chn, const char *attr_name, double value);
+inline int chn_attr_write_longlong(struct iio_channel *chn, const char *attr_name, long long value);
+
 #endif  /* __IIO_UTILS__ */

--- a/iio_utils.h
+++ b/iio_utils.h
@@ -52,5 +52,8 @@ inline int chn_attr_write_longlong(struct iio_channel *chn, const char *attr_nam
 inline void dev_attr_read_all(struct iio_device *dev,
     int (*cb)(struct iio_device *dev, const char *attr, const char *value, size_t len, void *d),
     void *data);
+inline void chn_attr_read_all(struct iio_channel *chn,
+    int (*cb)(struct iio_channel *chn, const char *attr, const char *value, size_t len, void *d),
+    void *data);
 
 #endif  /* __IIO_UTILS__ */

--- a/iio_widget.c
+++ b/iio_widget.c
@@ -14,6 +14,7 @@
 #include <math.h>
 
 #include "iio_widget.h"
+#include "iio_utils.h"
 
 struct update_widgets_params {
 	struct iio_widget *widgets;
@@ -696,7 +697,7 @@ void iio_update_widgets_of_device(struct iio_widget *widgets,
 	};
 
 	// !!!!!!!!
-//	iio_device_attr_read_all(dev, __cb_dev_update, &params);
+	dev_attr_read_all(dev, __cb_dev_update, &params);
 
 //	for (i = 0; i < iio_device_get_channels_count(dev); i++)
 //		iio_channel_attr_read_all(iio_device_get_channel(dev, i),

--- a/iio_widget.c
+++ b/iio_widget.c
@@ -696,12 +696,11 @@ void iio_update_widgets_of_device(struct iio_widget *widgets,
 		.nb = num_widgets,
 	};
 
-	// !!!!!!!!
 	dev_attr_read_all(dev, __cb_dev_update, &params);
 
-//	for (i = 0; i < iio_device_get_channels_count(dev); i++)
-//		iio_channel_attr_read_all(iio_device_get_channel(dev, i),
-//				__cb_chn_update, &params);
+	for (i = 0; i < iio_device_get_channels_count(dev); i++)
+		chn_attr_read_all(iio_device_get_channel(dev, i),
+				__cb_chn_update, &params);
 }
 
 void iio_save_widgets(struct iio_widget *widgets, unsigned int num_widgets)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 set(PLUGINS
 	generic_dac
-	#fmcomms2
+	fmcomms2
 	#fmcomms2_adv
 	#fmcomms5
 	#fmcomms6


### PR DESCRIPTION
## PR Description

This re-enabled the 'fmcomms2' plugin and updates it to use libiio v1.x API.
Additionally, it adds some helpers for iio attributes reading and writing. The purpose of the helpers is to reduce duplicated code and improve code readability.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [x] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
