### PR TITLE
plugins/fmcomms2_adv: Reenable and update to libiio 1.x API

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -18,7 +18,7 @@
 set(PLUGINS
 	generic_dac
 	fmcomms2
-	#fmcomms2_adv
+	fmcomms2_adv
 	fmcomms5
 	#fmcomms6
 	#fmcomms11


### PR DESCRIPTION
## PR Description

Reenable the 'fmcomms2_adv' plugin. This is only half done as it depends on the Oscplot which is currently WIP.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
