### PR TITLE
plugins: Update the CNxxxx plugins to use libiio v1.x API

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -32,10 +32,10 @@ set(PLUGINS
 	#ad9739a
 	#AD5628_1
 	#AD7303
-	#cn0357
-	#cn0508
-	#cn0511
-	#cn0540
+	cn0357
+	cn0508
+	cn0511
+	cn0540
 	#pr_config
 	#motor_control
 	#lidar

--- a/plugins/cn0357.c
+++ b/plugins/cn0357.c
@@ -28,6 +28,7 @@
 #include "../iio_widget.h"
 #include "../osc_plugin.h"
 #include "../config.h"
+#include "../iio_utils.h"
 
 #define THIS_DRIVER "CN0357"
 
@@ -105,7 +106,7 @@ static int get_adc_voltage(double *out_data)
 	long long raw;
 	int ret;
 
-	ret = iio_channel_attr_read_longlong(adc_ch, "raw", &raw);
+	ret = chn_attr_read_longlong(adc_ch, "raw", &raw);
 	if (!ret)
 		*out_data = V_TO_MV(ad7790_voltage_conversion(raw, V_REF_ADC, GAIN_ADC));
 
@@ -117,7 +118,7 @@ static int get_adc_power_supply(double *out_data)
 	long long raw;
 	int ret;
 
-	ret = iio_channel_attr_read_longlong(pwr_ch, "raw", &raw);
+	ret = chn_attr_read_longlong(pwr_ch, "raw", &raw);
 	if (!ret)
 		*out_data = ad7790_voltage_conversion(raw, V_REF_PWR, GAIN_PWR);
 
@@ -230,7 +231,7 @@ static void program_rdac_clicked_cb(GtkButton *btn, gpointer data)
 	if (!rdac_ch)
 		return;
 
-	iio_channel_attr_write(rdac_ch, "raw", gtk_entry_get_text(GTK_ENTRY(rdac_val)));
+	chn_attr_write_string(rdac_ch, "raw", gtk_entry_get_text(GTK_ENTRY(rdac_val)));
 }
 
 static gboolean update_display(gpointer foo)

--- a/plugins/cn0508.c
+++ b/plugins/cn0508.c
@@ -24,6 +24,7 @@
 #include "../iio_widget.h"
 #include "../osc_plugin.h"
 #include "../config.h"
+#include "../iio_utils.h"
 
 #define THIS_DRIVER "CN0508"
 
@@ -96,7 +97,7 @@ static int get_adc_voltage(struct iio_channel *adc_ch, double *out_data)
 	long long raw;
 	int ret;
 
-	ret = iio_channel_attr_read_longlong(adc_ch, "raw", &raw);
+	ret = chn_attr_read_longlong(adc_ch, "raw", &raw);
 	if (!ret)
 		*out_data = ad7124_voltage_conversion(raw, V_REF_ADC, GAIN_ADC);
 
@@ -263,17 +264,17 @@ static GtkWidget* cn0508_init(struct osc_plugin *plugin, GtkWidget *notebook,
 	current_pot_pos_ch = iio_device_find_channel(adc, "voltage5-voltage19", false);
 	voltage_pot_pos_ch = iio_device_find_channel(adc, "voltage6-voltage19", false);
 
-	iio_channel_attr_write(u2_temp_ch, "sampling_frequency", "9600");
-	iio_channel_attr_write(u3_temp_ch, "sampling_frequency", "9600");
-	iio_channel_attr_write(out_current_ch, "sampling_frequency", "9600");
-	iio_channel_attr_write(in_v_attenuator_ch, "sampling_frequency", "9600");
-	iio_channel_attr_write(out_v_attenuator_ch, "sampling_frequency", "9600");
-	iio_channel_attr_write(current_pot_pos_ch, "sampling_frequency", "9600");
-	iio_channel_attr_write(voltage_pot_pos_ch, "sampling_frequency", "9600");
+	chn_attr_write_string(u2_temp_ch, "sampling_frequency", "9600");
+	chn_attr_write_string(u3_temp_ch, "sampling_frequency", "9600");
+	chn_attr_write_string(out_current_ch, "sampling_frequency", "9600");
+	chn_attr_write_string(in_v_attenuator_ch, "sampling_frequency", "9600");
+	chn_attr_write_string(out_v_attenuator_ch, "sampling_frequency", "9600");
+	chn_attr_write_string(current_pot_pos_ch, "sampling_frequency", "9600");
+	chn_attr_write_string(voltage_pot_pos_ch, "sampling_frequency", "9600");
 
 	dac_ch = iio_device_find_channel(dac, "voltage0", true);
 
-	iio_channel_attr_read_double(dac_ch, "scale", &val);
+	chn_attr_read_double(dac_ch, "scale", &val);
 
 	iio_spin_button_int_init_from_builder(&iio_widgets[num_widgets++], dac,
 					      dac_ch, "raw", builder,

--- a/plugins/cn0511.c
+++ b/plugins/cn0511.c
@@ -10,11 +10,12 @@
 #include <math.h>
 
 #include <ad9166.h>
-#include <iio.h>
+#include <iio/iio.h>
 
 #include "../osc.h"
 #include "../osc_plugin.h"
 #include "../iio_widget.h"
+#include "../iio_utils.h"
 
 #define THIS_DRIVER	"CN0511"
 #define DAC_DEVICE	"ad9166"
@@ -146,12 +147,12 @@ static GtkWidget *cn0511_init(struct osc_plugin *plugin, GtkWidget *notebook,
 
 	dac_ch = iio_device_find_channel(dac, "altvoltage0", true);
 
-	ret = iio_device_attr_write_longlong(dac, "fir85_enable", 1);
+	ret = dev_attr_write_longlong(dac, "fir85_enable", 1);
 	if (ret < 0) {
 		fprintf(stderr, "Failed to enable FIR85. Error: %d\n", ret);
 	}
 
-	ret = iio_device_attr_write_longlong(dac, "sampling_frequency", 6000000000);
+	ret = dev_attr_write_longlong(dac, "sampling_frequency", 6000000000);
 	if (ret < 0) {
 		fprintf(stderr, "Failed to set sampling frequency. Error: %d\n", ret);
 	}


### PR DESCRIPTION
## PR Description

Re-enable plugins CN0357, CN0508, CN0511, CN0540 and update them to use libiio v1.x API.

## PR Type
- [x] New feature (a change that adds new functionality)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
