### PR TITLE
Libiio v1 support more plugins

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -43,7 +43,7 @@ set(PLUGINS
 	#debug
 	#spectrum_analyzer
 	#scpi
-	#ad9081
+	ad9081
 	#ad9084
 	#adrv9002
 	#cf_axi_tdd

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -24,8 +24,8 @@ set(PLUGINS
 	#fmcomms11
 	ad9371
 	ad9371_adv
-	#adrv9009
-	#adrv9009_adv
+	adrv9009
+	adrv9009_adv
 	#ad6676
 	#fmcadc3
 	#daq2

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -45,7 +45,7 @@ set(PLUGINS
 	#scpi
 	ad9081
 	ad9084
-	#adrv9002
+	adrv9002
 	#cf_axi_tdd
 	#xmw
 )

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -29,7 +29,7 @@ set(PLUGINS
 	ad6676
 	fmcadc3
 	daq2
-	#ad9739a
+	ad9739a
 	AD5628_1
 	#AD7303
 	cn0357

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -28,7 +28,7 @@ set(PLUGINS
 	adrv9009_adv
 	ad6676
 	fmcadc3
-	#daq2
+	daq2
 	#ad9739a
 	AD5628_1
 	#AD7303

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -44,7 +44,7 @@ set(PLUGINS
 	#spectrum_analyzer
 	#scpi
 	ad9081
-	#ad9084
+	ad9084
 	#adrv9002
 	#cf_axi_tdd
 	#xmw

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -26,17 +26,17 @@ set(PLUGINS
 	ad9371_adv
 	adrv9009
 	adrv9009_adv
-	#ad6676
-	#fmcadc3
+	ad6676
+	fmcadc3
 	#daq2
 	#ad9739a
-	#AD5628_1
+	AD5628_1
 	#AD7303
 	cn0357
 	cn0508
 	cn0511
 	cn0540
-	#pr_config
+	pr_config
 	#motor_control
 	#lidar
 	#dmm
@@ -46,8 +46,8 @@ set(PLUGINS
 	ad9081
 	ad9084
 	adrv9002
-	#cf_axi_tdd
-	#xmw
+	cf_axi_tdd
+	xmw
 )
 
 set(LIBAD9166_PLUGINS cn0511)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -22,8 +22,8 @@ set(PLUGINS
 	#fmcomms5
 	#fmcomms6
 	#fmcomms11
-	#ad9371
-	#ad9371_adv
+	ad9371
+	ad9371_adv
 	#adrv9009
 	#adrv9009_adv
 	#ad6676

--- a/plugins/ad9081.c
+++ b/plugins/ad9081.c
@@ -310,7 +310,7 @@ static void ad9081_label_writer(GtkBuilder *builder, struct iio_channel *voltage
 	if (!voltage)
 		return;
 
-	ret = iio_channel_attr_read(voltage, "label", buf, sizeof(buf));
+	ret = chn_attr_read_raw(voltage, "label", buf, sizeof(buf));
 	if (ret > 0) {
 		GtkWidget *label;
 		gchar *text, *id;
@@ -368,7 +368,7 @@ static void load_pfir(GtkFileChooser *chooser, gpointer data)
 	if (!buf)
 		goto err;
 
-	ret = iio_device_attr_write_raw(priv->ad9081, "filter_fir_config", buf, size);
+	ret = dev_attr_write_raw(priv->ad9081, "filter_fir_config", buf, size);
 	free(buf);
 	if (ret < 0)
 		goto err;
@@ -457,7 +457,7 @@ static GtkWidget *ad9081_init(struct osc_plugin *plugin, GtkWidget *notebook,
 	if (!ch0)
 		ch0 = iio_device_find_channel(ad9081_dev, "voltage0", FALSE);
 
-	if (ch0 && iio_channel_attr_read_longlong(ch0, "adc_frequency", &adc_freq) == 0)
+	if (ch0 && chn_attr_read_longlong(ch0, "adc_frequency", &adc_freq) == 0)
 		snprintf(attr_val, sizeof(attr_val), "%.2f",
 			 (double)(adc_freq / 1000000ul));
 	else
@@ -488,7 +488,7 @@ static GtkWidget *ad9081_init(struct osc_plugin *plugin, GtkWidget *notebook,
 	if (!ch0)
 		ch0 = iio_device_find_channel(ad9081_dev, "voltage0", TRUE);
 
-	if (ch0 && iio_channel_attr_read_longlong(ch0, "dac_frequency", &dac_freq) == 0)
+	if (ch0 && chn_attr_read_longlong(ch0, "dac_frequency", &dac_freq) == 0)
 		snprintf(attr_val, sizeof(attr_val), "%.2f",
 			 (double)(dac_freq / 1000000ul));
 	else
@@ -583,7 +583,7 @@ tx_chann:
 		gtk_widget_show_all(dds_container);
 
 		ch0 = iio_device_find_channel(dac, "altvoltage0", true);
-		if (iio_channel_attr_read_longlong(ch0, "sampling_frequency", &dac_freq) == 0)
+		if (chn_attr_read_longlong(ch0, "sampling_frequency", &dac_freq) == 0)
 			dac_tx_sampling_freq = (double)(dac_freq / 1000000ul);
 
 		dac_data_manager_freq_widgets_range_update(priv->dac_tx_manager,

--- a/plugins/ad9084.c
+++ b/plugins/ad9084.c
@@ -333,7 +333,7 @@ static void ad9084_label_writer(GtkBuilder *builder, struct iio_channel *voltage
 	if (!voltage)
 		return;
 
-	ret = iio_channel_attr_read(voltage, "label", buf, sizeof(buf));
+	ret = chn_attr_read_raw(voltage, "label", buf, sizeof(buf));
 	if (ret > 0) {
 		GtkWidget *label;
 		gchar *text, *id;
@@ -391,7 +391,7 @@ static void load_pfir(GtkFileChooser *chooser, gpointer data)
 	if (!buf)
 		goto err;
 
-	ret = iio_device_attr_write_raw(priv->ad9084, "pfilt_config", buf, size);
+	ret = dev_attr_write_raw(priv->ad9084, "pfilt_config", buf, size);
 	free(buf);
 	if (ret < 0)
 		goto err;
@@ -425,7 +425,7 @@ static void load_cfir(GtkFileChooser *chooser, gpointer data)
 	if (!buf)
 		goto err;
 
-	ret = iio_device_attr_write_raw(priv->ad9084, "cfir_config", buf, size);
+	ret = dev_attr_write_raw(priv->ad9084, "cfir_config", buf, size);
 	free(buf);
 	if (ret < 0)
 		goto err;
@@ -521,7 +521,7 @@ static GtkWidget *ad9084_init(struct osc_plugin *plugin, GtkWidget *notebook,
 	if (!ch0)
 		ch0 = iio_device_find_channel(ad9084_dev, "voltage0", FALSE);
 
-	if (ch0 && iio_channel_attr_read_longlong(ch0, "adc_frequency", &adc_freq) == 0)
+	if (ch0 && chn_attr_read_longlong(ch0, "adc_frequency", &adc_freq) == 0)
 		snprintf(attr_val, sizeof(attr_val), "%.2f",
 			 (double)(adc_freq / 1000000ul));
 	else
@@ -552,7 +552,7 @@ static GtkWidget *ad9084_init(struct osc_plugin *plugin, GtkWidget *notebook,
 	if (!ch0)
 		ch0 = iio_device_find_channel(ad9084_dev, "voltage0", TRUE);
 
-	if (ch0 && iio_channel_attr_read_longlong(ch0, "dac_frequency", &dac_freq) == 0)
+	if (ch0 && chn_attr_read_longlong(ch0, "dac_frequency", &dac_freq) == 0)
 		snprintf(attr_val, sizeof(attr_val), "%.2f",
 			 (double)(dac_freq / 1000000ul));
 	else
@@ -647,7 +647,7 @@ tx_chann:
 		gtk_widget_show_all(dds_container);
 
 		ch0 = iio_device_find_channel(dac, "altvoltage0", true);
-		if (iio_channel_attr_read_longlong(ch0, "sampling_frequency", &dac_freq) == 0)
+		if (chn_attr_read_longlong(ch0, "sampling_frequency", &dac_freq) == 0)
 			dac_tx_sampling_freq = (double)(dac_freq / 1000000ul);
 
 		dac_data_manager_freq_widgets_range_update(priv->dac_tx_manager,

--- a/plugins/ad9371_adv.c
+++ b/plugins/ad9371_adv.c
@@ -23,7 +23,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <iio.h>
+#include <iio/iio.h>
 
 #include "../libini2.h"
 #include "../osc.h"
@@ -31,6 +31,7 @@
 #include "../config.h"
 #include "../iio_widget.h"
 #include "../datatypes.h"
+#include "../iio_utils.h"
 
 
 #define PHY_DEVICE "ad9371-phy"
@@ -42,8 +43,6 @@
 
 static struct iio_context *ctx;
 static struct iio_device *dev;
-
-OscPlot *plot_xcorr_4ch;
 
 static bool can_update_widgets;
 
@@ -843,7 +842,7 @@ static void signal_handler_cb (GtkWidget *widget, gpointer data)
 			val = (long long) gtk_spin_button_get_value(GTK_SPIN_BUTTON (widget));
 
 			if (item->lut_len) {
-				iio_device_debug_attr_read_longlong(dev, item->name, &mask);
+				dev_debug_attr_read_longlong(dev, item->name, &mask);
 				mask &= ~((1 << item->lut_len) - 1);
 				mask |= val & ((1 << item->lut_len) - 1);
 				val = mask;
@@ -863,21 +862,21 @@ static void signal_handler_cb (GtkWidget *widget, gpointer data)
 			if (ret != 2)
 				return;
 
-			iio_device_debug_attr_read_longlong(dev, str, &mask);
+			dev_debug_attr_read_longlong(dev, str, &mask);
 
 			if (val) {
 				mask |= (1 << bit);
 			} else {
 				mask &= ~(1 << bit);
 			}
-			iio_device_debug_attr_write_longlong(dev, str, mask);
+			dev_debug_attr_write_longlong(dev, str, mask);
 
 			return;
 		default:
 			return;
 	}
 
-	iio_device_debug_attr_write_longlong(dev, item->name, val);
+	dev_debug_attr_write_longlong(dev, item->name, val);
 
 	if (!strcmp(item->name, "initialize")) {
 		reload_settings();
@@ -900,8 +899,8 @@ static void bist_tone_cb (GtkWidget *widget, gpointer data)
 
 	sprintf(temp, "%u %u %u", enable, tx1_freq, tx2_freq);
 
-	iio_device_debug_attr_write(dev, "bist_tone", "0 0 0");
-	iio_device_debug_attr_write(dev, "bist_tone", temp);
+	dev_debug_attr_write_string(dev, "bist_tone", "0 0 0");
+	dev_debug_attr_write_string(dev, "bist_tone", temp);
 }
 
 static char * set_widget_value(GtkWidget *widget, struct w_info *item, long long val)
@@ -1013,12 +1012,12 @@ static int __update_widget(struct iio_device *dev, const char *attr,
 
 static int connect_widgets(GtkBuilder *builder)
 {
-	return iio_device_debug_attr_read_all(dev, __connect_widget, builder);
+	return dev_debug_attr_read_all(dev, __connect_widget, builder);
 }
 
 static int update_widgets(GtkBuilder *builder)
 {
-	return iio_device_debug_attr_read_all(dev, __update_widget, builder);
+	return dev_debug_attr_read_all(dev, __update_widget, builder);
 }
 
 static void change_page_cb (GtkNotebook *notebook, GtkNotebookTab *page,

--- a/plugins/ad9739a.c
+++ b/plugins/ad9739a.c
@@ -22,7 +22,7 @@
 #include <sys/stat.h>
 #include <string.h>
 
-#include <iio.h>
+#include <iio/iio.h>
 
 #include "../libini2.h"
 #include "../osc.h"

--- a/plugins/adrv9009.c
+++ b/plugins/adrv9009.c
@@ -248,7 +248,7 @@ static void multichip_sync()
 		return;
 
 	/* Check for and skip in case of JESD204-FSM support */
-	ret = iio_device_attr_write_longlong(subcomponents[0].iio_dev, "multichip_sync", 424242);
+	ret = dev_attr_write_longlong(subcomponents[0].iio_dev, "multichip_sync", 424242);
 	if (ret != -EINVAL)
 		return;
 
@@ -272,7 +272,7 @@ static void multichip_sync()
 	for (; i <= 11; i++) {
 		guint n = 0;
 		for (; n < phy_devs_count; n++) {
-			iio_device_attr_write_longlong(subcomponents[n].iio_dev, "multichip_sync", i);
+			dev_attr_write_longlong(subcomponents[n].iio_dev, "multichip_sync", i);
 		}
 	}
 }
@@ -287,7 +287,7 @@ static void update_label_from(GtkWidget *label, struct iio_device *dev, const ch
 
 	ch = iio_device_find_channel(dev, channel, output);
 	if (ch) {
-		ret = iio_channel_attr_read_longlong(ch, attribute, &val);
+		ret = chn_attr_read_longlong(ch, attribute, &val);
 
 		if (scale == 1)
 			snprintf(buf, sizeof(buf), "%lld %s", val, unit);
@@ -362,7 +362,7 @@ int load_tal_profile(const char *file_name,
 		ret = INT_MAX;
 		guint i = 0;
 		for (; i < phy_devs_count; i++) {
-			ret2 = iio_device_attr_write_raw(subcomponents[i].iio_dev, "profile_config", buf, len);
+			ret2 = dev_attr_write_raw(subcomponents[i].iio_dev, "profile_config", buf, len);
 			ret = (ret > ret2) ? ret2 : ret;
 		}
 
@@ -422,7 +422,7 @@ static void glb_settings_update_labels(void)
 
 	/* Get ensm_mode from all devices. Notify user if any of devices has a different mode than the others. */
 	for (; i < phy_devs_count; i++) {
-		ret = iio_device_attr_read(subcomponents[i].iio_dev, "ensm_mode", buf, sizeof(buf));
+		ret = dev_attr_read_raw(subcomponents[i].iio_dev, "ensm_mode", buf, sizeof(buf));
 		if (ret > 0) {
 			if (i > 0) {
 				if (strncmp(buf, gtk_label_get_text(GTK_LABEL(ensm_mode)), sizeof(buf))) {
@@ -441,7 +441,7 @@ static void glb_settings_update_labels(void)
 	for (i = 0; i < phy_devs_count; i++) {
 		ch = iio_device_find_channel(subcomponents[i].iio_dev, "voltage0", false);
 		if (ch) {
-			ret = iio_channel_attr_read(ch, "gain_control_mode", buf, sizeof(buf));
+			ret = chn_attr_read_raw(ch, "gain_control_mode", buf, sizeof(buf));
 		} else {
 			ret = 0;
 		}
@@ -453,7 +453,7 @@ static void glb_settings_update_labels(void)
 
 		ch = iio_device_find_channel(subcomponents[i].iio_dev, "voltage1", false);
 		if (ch) {
-			ret = iio_channel_attr_read(ch, "gain_control_mode", buf, sizeof(buf));
+			ret = chn_attr_read_raw(ch, "gain_control_mode", buf, sizeof(buf));
 		} else {
 			ret = 0;
 		}
@@ -496,7 +496,7 @@ static void set_ensm_mode_of_all_devices(const char *mode)
 	guint i = 0;
 
 	for (; i < phy_devs_count; i++) {
-		iio_device_attr_write_raw(subcomponents[i].iio_dev, "ensm_mode", mode, strlen(mode));
+		dev_attr_write_raw(subcomponents[i].iio_dev, "ensm_mode", mode, strlen(mode));
 	}
 }
 
@@ -568,7 +568,7 @@ static void int_dec_freq_update(void)
 		return;
 
 	ch = iio_device_find_channel(cap, "voltage0_i", false);
-	iio_channel_attr_read_double(ch, "sampling_frequency", &freq);
+	chn_attr_read_double(ch, "sampling_frequency", &freq);
 	text = g_strdup_printf ("%f", freq / mhz_scale);
 
 	guint i = 0;
@@ -581,7 +581,7 @@ static void int_dec_freq_update(void)
 
 	ch = iio_device_find_channel(dds, "voltage0", true);
 	text = g_strdup_printf ("%f", freq / mhz_scale);
-	iio_channel_attr_read_double(ch, "sampling_frequency", &freq);
+	chn_attr_read_double(ch, "sampling_frequency", &freq);
 
 	for (i = 0; i < phy_devs_count; i++)
 		gtk_label_set_text(GTK_LABEL(subcomponents[i].label_sampling_freq_tx), text);
@@ -603,7 +603,7 @@ static void rssi_update_label(GtkWidget *label, struct iio_channel *ch)
 	if (!gtk_widget_is_drawable(GTK_WIDGET(label)))
 		return;
 
-	ret = iio_channel_attr_read(ch, "rssi", buf, sizeof(buf));
+	ret = chn_attr_read_raw(ch, "rssi", buf, sizeof(buf));
 	if (ret > 0)
 		gtk_label_set_text(GTK_LABEL(label), buf);
 	else
@@ -666,10 +666,10 @@ static void rx_phase_rotation_update()
 		struct iio_channel *i_chn = g_array_index(out, struct iio_channel*, i);
 		struct iio_channel *q_chn = g_array_index(out, struct iio_channel*, i + 1);
 
-		iio_channel_attr_read_double(i_chn, "calibscale", &val[0]);
-		iio_channel_attr_read_double(i_chn, "calibphase", &val[1]);
-		iio_channel_attr_read_double(q_chn, "calibscale", &val[2]);
-		iio_channel_attr_read_double(q_chn, "calibphase", &val[3]);
+		chn_attr_read_double(i_chn, "calibscale", &val[0]);
+		chn_attr_read_double(i_chn, "calibphase", &val[1]);
+		chn_attr_read_double(q_chn, "calibscale", &val[2]);
+		chn_attr_read_double(q_chn, "calibphase", &val[3]);
 
 		val[0] = acos(val[0]) * 360.0 / (2.0 * M_PI);
 		val[1] = asin(-1.0 * val[1]) * 360.0 / (2.0 * M_PI);
@@ -836,10 +836,10 @@ static void rx_phase_rotation_set(GtkSpinButton *spinbutton, gpointer user_data)
 	}
 
 	if (out1 && out0) {
-		iio_channel_attr_write_double(out0, "calibscale", (double) cos(phase));
-		iio_channel_attr_write_double(out0, "calibphase", (double)(-1 * sin(phase)));
-		iio_channel_attr_write_double(out1, "calibscale", (double) cos(phase));
-		iio_channel_attr_write_double(out1, "calibphase", (double) sin(phase));
+		chn_attr_write_double(out0, "calibscale", (double) cos(phase));
+		chn_attr_write_double(out0, "calibphase", (double)(-1 * sin(phase)));
+		chn_attr_write_double(out1, "calibscale", (double) cos(phase));
+		chn_attr_write_double(out1, "calibphase", (double) sin(phase));
 	}
 }
 
@@ -1032,7 +1032,7 @@ static void load_profile(struct osc_plugin *plugin, const char *ini_fn)
 		g_free(attrib_name);
 
 		if (ch && value) {
-			iio_channel_attr_write(ch, "gain_control_mode", value);
+			chn_attr_write_string(ch, "gain_control_mode", value);
 			free(value);
 		}
 
@@ -1042,7 +1042,7 @@ static void load_profile(struct osc_plugin *plugin, const char *ini_fn)
 		g_free(attrib_name);
 
 		if (ch && value) {
-			iio_channel_attr_write(ch, "gain_control_mode", value);
+			chn_attr_write_string(ch, "gain_control_mode", value);
 			free(value);
 		}
 

--- a/plugins/adrv9009_adv.c
+++ b/plugins/adrv9009_adv.c
@@ -23,7 +23,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <iio.h>
+#include <iio/iio.h>
 
 #include "../libini2.h"
 #include "../osc.h"
@@ -791,7 +791,7 @@ static void signal_handler_cb(GtkWidget *widget, gpointer data)
 		val = (long long) gtk_spin_button_get_value(GTK_SPIN_BUTTON(widget));
 
 		if (item->lut_len) {
-			iio_device_debug_attr_read_longlong(plugin->priv->dev, item->name, &mask);
+			dev_debug_attr_read_longlong(plugin->priv->dev, item->name, &mask);
 			mask &= ~((1 << item->lut_len) - 1);
 			mask |= val & ((1 << item->lut_len) - 1);
 			val = mask;
@@ -815,7 +815,7 @@ static void signal_handler_cb(GtkWidget *widget, gpointer data)
 		if (ret != 2)
 			return;
 
-		iio_device_debug_attr_read_longlong(plugin->priv->dev, str, &mask);
+		dev_debug_attr_read_longlong(plugin->priv->dev, str, &mask);
 
 		if (val) {
 			mask |= (1 << bit);
@@ -823,7 +823,7 @@ static void signal_handler_cb(GtkWidget *widget, gpointer data)
 			mask &= ~(1 << bit);
 		}
 
-		iio_device_debug_attr_write_longlong(plugin->priv->dev, str, mask);
+		dev_debug_attr_write_longlong(plugin->priv->dev, str, mask);
 
 		return;
 
@@ -831,7 +831,7 @@ static void signal_handler_cb(GtkWidget *widget, gpointer data)
 		return;
 	}
 
-	iio_device_debug_attr_write_longlong(plugin->priv->dev, item->name, val);
+	dev_debug_attr_write_longlong(plugin->priv->dev, item->name, val);
 
 	if (!strcmp(item->name, "initialize")) {
 		reload_settings();
@@ -854,8 +854,8 @@ static void bist_tone_cb(GtkWidget *widget, gpointer data)
 
 	sprintf(temp, "%u %u %u", enable, tx1_freq, tx2_freq);
 
-	iio_device_debug_attr_write(plugin->priv->dev, "bist_tone", "0 0 0");
-	iio_device_debug_attr_write(plugin->priv->dev, "bist_tone", temp);
+	dev_debug_attr_write_string(plugin->priv->dev, "bist_tone", "0 0 0");
+	dev_debug_attr_write_string(plugin->priv->dev, "bist_tone", temp);
 }
 
 static char *set_widget_value(GtkWidget *widget, struct w_info *item, long long val)
@@ -990,12 +990,12 @@ static int __update_widget(struct iio_device *dev, const char *attr,
 
 static int connect_widgets(struct osc_plugin *plugin)
 {
-	return iio_device_debug_attr_read_all(plugin->priv->dev, __connect_widget, plugin);
+	return dev_debug_attr_read_all(plugin->priv->dev, __connect_widget, plugin);
 }
 
 static int update_widgets(struct osc_plugin *plugin)
 {
-	return iio_device_debug_attr_read_all(plugin->priv->dev, __update_widget, plugin->priv->builder);
+	return dev_debug_attr_read_all(plugin->priv->dev, __update_widget, plugin->priv->builder);
 }
 
 static void change_page_cb(GtkNotebook *notebook, GtkNotebookTab *page,

--- a/plugins/daq2.c
+++ b/plugins/daq2.c
@@ -21,8 +21,9 @@
 #include <sys/stat.h>
 #include <string.h>
 
-#include <iio.h>
+#include <iio/iio.h>
 
+#include "../iio_utils.h"
 #include "../libini2.h"
 #include "../osc.h"
 #include "../iio_widget.h"
@@ -296,7 +297,7 @@ static GtkWidget * daq2_init(struct osc_plugin *plugin, GtkWidget *notebook, con
 	ch0 = iio_device_find_channel(adc, "voltage0", false);
 	ch1 = iio_device_find_channel(adc, "voltage1", false);
 
-	if (iio_channel_attr_read_longlong(ch0, "sampling_frequency", &val) == 0)
+	if (chn_attr_read_longlong(ch0, "sampling_frequency", &val) == 0)
 		snprintf(attr_val, sizeof(attr_val), "%.3f", (double)val / 1000000.0);
 	else
 		snprintf(attr_val, sizeof(attr_val), "%s", "error");
@@ -314,7 +315,7 @@ static GtkWidget * daq2_init(struct osc_plugin *plugin, GtkWidget *notebook, con
 	/* Tx Widgets */
 	ch0 = iio_device_find_channel(dac, "altvoltage0", true);
 
-	if (iio_channel_attr_read_longlong(ch0, "sampling_frequency", &val) == 0) {
+	if (chn_attr_read_longlong(ch0, "sampling_frequency", &val) == 0) {
 		tx_sampling_freq = (double)val / 1000000.0;
 		snprintf(attr_val, sizeof(attr_val), "%.3f", tx_sampling_freq);
 	} else {


### PR DESCRIPTION
## PR Description

Re-enable plugins: AD9081, AD9084, ADRV9002, AD9371, ADRV9009 and update them to use libiio v1.x.
Also, re-enable plugins: ad6676, fmcadc3, pr_config, cf_axi_tdd, xmw, ad5628_1.

## PR Type
- [x] New feature (a change that adds new functionality)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
