### PR TITLE
ci/buildmingw.yml: fix deprecated version of upload-artifact

### DIFF
--- a/.github/workflows/buildmingw.yml
+++ b/.github/workflows/buildmingw.yml
@@ -40,7 +40,7 @@ jobs:
                 -e LIBAD9166_BRANCH=main ^
                 shooteu/iio-oscilloscope C:\msys64\usr\bin\bash.exe -c '/home/docker/iio-oscilloscope/CI/docker/inside_docker.sh'
             
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: adi-osc-setup
         path: ${{ github.workspace }}\artifacts\adi-osc-setup.exe


### PR DESCRIPTION
## PR Description

Github CI fails for MinGW builds due to a deprecated version.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [x] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [x] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
