### PR TITLE
glade/oscplot: Fix runtime GTK3 warning when creating plot

### DIFF
--- a/glade/oscplot.glade
+++ b/glade/oscplot.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkAdjustment" id="adj_add_to_sample">
@@ -1608,19 +1608,16 @@
       </object>
     </child>
   </object>
-  <object class="GtkFileChooserDialog" id="saveas_dialog">
+  <object class="GtkDialog" id="saveas_dialog">
     <property name="can-focus">False</property>
-    <property name="border-width">5</property>
     <property name="title" translatable="yes">ADI IIO oscilloscope - Save As</property>
-    <property name="role">GtkFileChooserDialog</property>
     <property name="modal">True</property>
     <property name="icon-name">adi-osc</property>
     <property name="type-hint">dialog</property>
-    <property name="action">save</property>
-    <property name="do-overwrite-confirmation">True</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="filechooserdialog-vbox3">
         <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="filechooserdialog-action_area3">
@@ -1653,7 +1650,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">5</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
@@ -1661,6 +1658,20 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFileChooserWidget" id="saveas_filechooser_widget">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="action">select-folder</property>
+            <property name="do-overwrite-confirmation">True</property>
+            <property name="search-mode">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>

--- a/oscplot.c
+++ b/oscplot.c
@@ -274,6 +274,7 @@ struct _OscPlotPrivate
 	GtkWidget *phase_label;
 	GtkWidget *saveas_button;
 	GtkWidget *saveas_dialog;
+	GtkFileChooser *saveas_filechooser;
 	GtkWidget *saveas_type_dialog;
 	GtkWidget *title_edit_dialog;
 	GtkWidget *fullscreen_button;
@@ -4550,14 +4551,14 @@ static void saveas_dialog_show(GtkWidget *w, OscPlot *plot)
 {
 	OscPlotPrivate *priv = plot->priv;
 
-	gtk_file_chooser_set_action(GTK_FILE_CHOOSER (priv->saveas_dialog), GTK_FILE_CHOOSER_ACTION_SAVE);
-	gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(priv->saveas_dialog), TRUE);
+	gtk_file_chooser_set_action(priv->saveas_filechooser, GTK_FILE_CHOOSER_ACTION_SAVE);
+	gtk_file_chooser_set_do_overwrite_confirmation(priv->saveas_filechooser, TRUE);
 
 	if (!priv->saveas_filename) {
-		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER (priv->saveas_dialog), getenv("HOME"));
+		gtk_file_chooser_set_current_folder(priv->saveas_filechooser, getenv("HOME"));
 	} else {
-		if (!gtk_file_chooser_set_filename(GTK_FILE_CHOOSER (priv->saveas_dialog), priv->saveas_filename))
-			gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER (priv->saveas_dialog), getenv("HOME"));
+		if (!gtk_file_chooser_set_filename(priv->saveas_filechooser, priv->saveas_filename))
+			gtk_file_chooser_set_current_folder(priv->saveas_filechooser, getenv("HOME"));
 		g_free(priv->saveas_filename);
 		priv->saveas_filename = NULL;
 	}
@@ -4794,7 +4795,7 @@ void cb_saveas_response(GtkDialog *dialog, gint response_id, OscPlot *plot)
 	/* Save as Dialog */
 	OscPlotPrivate *priv = plot->priv;
 
-	priv->saveas_filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (priv->saveas_dialog));
+	priv->saveas_filename = gtk_file_chooser_get_filename(priv->saveas_filechooser);
 
 	if (response_id == GTK_RESPONSE_ACCEPT) {
 		gint type = gtk_combo_box_get_active(GTK_COMBO_BOX(priv->cmb_saveas_type));
@@ -6985,6 +6986,7 @@ static void create_plot(OscPlot *plot)
 	priv->phase_label = GTK_WIDGET(gtk_builder_get_object(builder, "phase_info"));
 	priv->saveas_button = GTK_WIDGET(gtk_builder_get_object(builder, "save_as"));
 	priv->saveas_dialog = GTK_WIDGET(gtk_builder_get_object(builder, "saveas_dialog"));
+	priv->saveas_filechooser = GTK_FILE_CHOOSER(gtk_builder_get_object(builder, "saveas_filechooser_widget"));
 	priv->title_edit_dialog = GTK_WIDGET(gtk_builder_get_object(builder, "dialog_plot_title_edit"));
 	priv->fullscreen_button = GTK_WIDGET(gtk_builder_get_object(builder, "fullscreen"));
 	priv->menu_fullscreen = GTK_WIDGET(gtk_builder_get_object(builder, "menuitem_fullscreen"));


### PR DESCRIPTION
## PR Description

Get rid of GTK3 runtime warning each time an iio-osc plot is being created.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
