### PR TITLE
#493: Linux startup problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,15 @@ set_target_properties(oscmain PROPERTIES OUTPUT_NAME osc)
 
 # Fix libosc.0.so not found
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  set(CMAKE_INSTALL_LIBDIR "/lib")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7|x86_64)$")
+    set(CMAKE_INSTALL_LIBDIR "/lib")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|ppc64le|s390x)$")
+    set(CMAKE_INSTALL_LIBDIR "/usr/local/lib")
+  else()
+    set(CMAKE_INSTALL_LIBDIR "/usr/local/lib")
+  endif()
 endif()
+
 
 install(TARGETS osc
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,11 @@ target_link_libraries(oscmain PRIVATE
 )
 set_target_properties(oscmain PROPERTIES OUTPUT_NAME osc)
 
+# Fix libosc.0.so not found
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(CMAKE_INSTALL_LIBDIR "/lib")
+endif()
+
 install(TARGETS osc
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,14 +249,11 @@ target_link_libraries(oscmain PRIVATE
 )
 set_target_properties(oscmain PROPERTIES OUTPUT_NAME osc)
 
-# Fix libosc.0.so not found
+# Fix libosc.0.so not found 
+# (Ubuntu and Debian armv7 & x86_64 systems)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7|x86_64)$")
     set(CMAKE_INSTALL_LIBDIR "/lib")
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|ppc64le|s390x)$")
-    set(CMAKE_INSTALL_LIBDIR "/usr/local/lib")
-  else()
-    set(CMAKE_INSTALL_LIBDIR "/usr/local/lib")
   endif()
 endif()
 


### PR DESCRIPTION
CMakeLists.txt library installation directory was changed from /usr/local/lib to /lib because most of the Linux distributions don't include /usr/local/lib on LD_PATH

