### PR TITLE
AD9371 Plugin - Fix Spinbox for RX2 gain

### DIFF
--- a/plugins/ad9371.c
+++ b/plugins/ad9371.c
@@ -729,8 +729,6 @@ static gboolean update_display(gpointer foo)
 			clgc_update_labels();
 			vswr_update_labels();
 		}
-
-		iio_widget_update(&rx_widgets[rx2_gain]);
 	}
 
 	return TRUE;


### PR DESCRIPTION


## PR Description
the call to iio_widget_update caused the value for RX2 gain in the spin box to be overwritten unless the Enter key was pressed
now spin box for RX2 gain behaves like RX1 gain
## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
