### PR TITLE
osc: Use device ID when name or label fails

### DIFF
--- a/osc.c
+++ b/osc.c
@@ -1830,7 +1830,8 @@ static void init_device_list(struct iio_context *_ctx)
 		}
 
 		rx_update_device_sampling_freq(
-			get_iio_device_label_or_name(dev), USE_INTERN_SAMPLING_FREQ);
+			get_iio_device_label_or_name(dev) ?: iio_device_get_id(dev),
+			USE_INTERN_SAMPLING_FREQ);
 	}
 }
 


### PR DESCRIPTION
## PR Description
The following error message was being displayed at startup: CRITICAL **: rx_update_device_sampling_freq: assertion 'device' failed

This was due to the existence of:
/sys/bus/iio/device/iio_sysfs_trigger
which doesn't have the 'name' attribute.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
