### PR TITLE
dialogs: fix compilation when serial is not available

### DIFF
--- a/dialogs.c
+++ b/dialogs.c
@@ -587,6 +587,7 @@ nope:
 
 static void refresh_serial(GtkBuilder *builder)
 {
+#ifdef SERIAL_BACKEND
 	GtkListStore *liststore;
 	struct sp_port **ports;
 	int i, active = 0;
@@ -620,6 +621,7 @@ static void refresh_serial(GtkBuilder *builder)
 		gtk_widget_set_sensitive(dialogs.connect_serial, false);
 		gtk_widget_set_sensitive(dialogs.connect_serialbits, false);
 	}
+#endif
 }
 
 char * usb_get_serialnumber(struct iio_context *context)


### PR DESCRIPTION
In commit 8d4b9f0 ("dialogs: improve serial handling"), we dropped the '#ifdef' but that will break compilation in case libserial is not installed as it's used functions won't be available. Fix it by reintroduced the defined set by cmake.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
