### PR TITLE
Fixed segmentation fault if no ADRV9002 device is found

### DIFF
--- a/osc.c
+++ b/osc.c
@@ -1107,6 +1107,13 @@ static void load_plugins(GtkWidget *notebook, const char *ini_fn)
 			}
 
 			GArray *plugin_info = get_plugins_info();
+
+			if (plugin_info == NULL) {
+				fprintf(stderr, "Failed to load plugin \"%s\"", ent->d_name);
+				dlclose(lib);
+				continue;
+			}
+ 
 			if (plugin_info->len == 0) {
 				dlclose(lib);
 				continue;


### PR DESCRIPTION
## PR Description

- Segmentation fault is happening, when trying to load the plugin ADRV9002, if none of this devices are found in the current context. Therefore I checked if the plugin_info is NULL to prevent a segmentation fault.
- If no adrv9002 are found, the plugin will not be loaded.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
