### PR TITLE
Libiio v1 reenable libini2 calls

### DIFF
--- a/iio_utils.c
+++ b/iio_utils.c
@@ -430,3 +430,124 @@ void chn_attr_read_all(struct iio_channel *chn,
 		}
 	}
 }
+
+int dev_attr_write_all(struct iio_device *dev,
+    ssize_t (*cb)(struct iio_device *dev, const char *attr, void *buf, size_t len, void *d),
+    void *data)
+{
+	const struct iio_attr *attr;
+	unsigned int i, nb_attrs;
+	size_t len = 0x100000;
+	const char *name;
+	char *buf;
+	ssize_t count;
+	int ret = 0;
+
+	buf = malloc(len);
+	if (!buf)
+		return -ENOMEM;
+
+	nb_attrs = iio_device_get_attrs_count(dev);
+
+	for (i = 0; i < nb_attrs; i++) {
+		attr = iio_device_get_attr(dev, i);
+		name = iio_attr_get_name(attr);
+
+		count = (*cb)(dev, name, buf, len, data);
+		if (count < 0) {
+			ret = (int)count;
+			goto out_free_buffer;
+		}
+
+		count = iio_attr_write_raw(attr, buf, count);
+		if (count < 0) {
+			ret = (int)count;
+			goto out_free_buffer;
+		}
+	}
+
+out_free_buffer:
+	free(buf);
+
+	return ret;
+}
+
+int dev_debug_attr_write_all(struct iio_device *dev,
+    ssize_t (*cb)(struct iio_device *dev, const char *attr, void *buf, size_t len, void *d),
+    void *data)
+{
+	const struct iio_attr *attr;
+	unsigned int i, nb_attrs;
+	size_t len = 0x100000;
+	const char *name;
+	char *buf;
+	ssize_t count;
+	int ret = 0;
+
+	buf = malloc(len);
+	if (!buf)
+		return -ENOMEM;
+
+	nb_attrs = iio_device_get_debug_attrs_count(dev);
+
+	for (i = 0; i < nb_attrs; i++) {
+		attr = iio_device_get_debug_attr(dev, i);
+		name = iio_attr_get_name(attr);
+
+		count = (*cb)(dev, name, buf, len, data);
+		if (count < 0) {
+			ret = (int)count;
+			goto out_free_buffer;
+		}
+
+		count = iio_attr_write_raw(attr, buf, count);
+		if (count < 0) {
+			ret = (int)count;
+			goto out_free_buffer;
+		}
+	}
+
+out_free_buffer:
+	free(buf);
+
+	return ret;
+}
+
+int chn_attr_write_all(struct iio_channel *chn,
+    ssize_t (*cb)(struct iio_channel *chn, const char *attr, void *buf, size_t len, void *d),
+    void *data)
+{
+	unsigned int i, attr_cnt = iio_channel_get_attrs_count(chn);
+	const struct iio_attr *attr;
+	const char *name;
+	ssize_t count;
+	size_t len = 0x100000;
+	char *buf;
+	int ret = 0;
+
+	buf = malloc(len);
+	if (!buf)
+		return -ENOMEM;
+
+	for (i = 0; i < attr_cnt; ++i) {
+		attr = iio_channel_get_attr(chn, i);
+		name = iio_attr_get_name(attr);
+
+		count = (*cb)(chn, name, buf, len, data);
+		if (count < 0) {
+			ret = (int)count;
+			goto out_free_buffer;
+		}
+
+		count = iio_attr_write_raw(attr, buf, count);
+		if (count < 0) {
+			ret = (int)count;
+			goto out_free_buffer;
+		}
+	}
+
+out_free_buffer:
+	free(buf);
+
+	return ret;
+}

--- a/iio_utils.h
+++ b/iio_utils.h
@@ -58,11 +58,20 @@ inline int chn_attr_write_longlong(struct iio_channel *chn, const char *attr_nam
 inline void dev_attr_read_all(struct iio_device *dev,
     int (*cb)(struct iio_device *dev, const char *attr, const char *value, size_t len, void *d),
     void *data);
+inline int dev_attr_write_all(struct iio_device *dev,
+        ssize_t (*cb)(struct iio_device *dev, const char *attr, void *buf, size_t len, void *d),
+        void *data);
 inline int dev_debug_attr_read_all(struct iio_device *dev,
     int (*cb)(struct iio_device *dev, const char *attr, const char *value, size_t len, void *d),
     void *data);
+inline int dev_debug_attr_write_all(struct iio_device *dev,
+        ssize_t (*cb)(struct iio_device *dev, const char *attr, void *buf, size_t len, void *d),
+        void *data);
 inline void chn_attr_read_all(struct iio_channel *chn,
-    int (*cb)(struct iio_channel *chn, const char *attr, const char *value, size_t len, void *d),
+        int (*cb)(struct iio_channel *chn, const char *attr, const char *value, size_t len, void *d),
     void *data);
+inline int chn_attr_write_all(struct iio_channel *chn,
+        ssize_t (*cb)(struct iio_channel *chn, const char *attr, void *buf, size_t len, void *d),
+        void *data);
 
 #endif  /* __IIO_UTILS__ */

--- a/libini2.c
+++ b/libini2.c
@@ -160,16 +160,15 @@ void update_from_ini(const char *ini_file,
 
 	params.section_top = name + nlen + 1;
 
-	/*for (i = 0; i < iio_device_get_channels_count(dev); i++) {
-		iio_channel_attr_write_all(iio_device_get_channel(dev, i),
+	for (i = 0; i < iio_device_get_channels_count(dev); i++) {
+		chn_attr_write_all(iio_device_get_channel(dev, i),
 				update_from_ini_chn_cb, &params);
-		iio_attr_write()
 		}
 	if (iio_device_get_attrs_count(dev))
-		iio_device_attr_write_all(dev, update_from_ini_dev_cb, &params);
+		dev_attr_write_all(dev, update_from_ini_dev_cb, &params);
 
 	params.is_debug = true;
-	iio_device_debug_attr_write_all(dev, update_from_ini_dev_cb, &params);*/
+	dev_debug_attr_write_all(dev, update_from_ini_dev_cb, &params);
 
 	ini_close(ini);
 }


### PR DESCRIPTION
## PR Description

Reenable call to writing all attributes of channels or devices.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
