### PR TITLE
Fix -Wdiscarded-qualifiers warnings with modern GCC

### DIFF
--- a/osc.c
+++ b/osc.c
@@ -2861,7 +2861,7 @@ static int osc_read_enclosed_value(struct iio_context *_ctx,
 		return ret;
 	}
 
-	ptr = strchr(value + 1, '}');
+	ptr = (gchar *)strchr(value + 1, '}');
 	if (!ptr)
 		return -EINVAL;
 
@@ -2871,7 +2871,7 @@ static int osc_read_enclosed_value(struct iio_context *_ctx,
 	if (ret < 0)
 		return ret;
 
-	ptr = strchr(value + 2, '{');
+	ptr = (gchar *)strchr(value + 2, '{');
 	if (!ptr)
 		return -EINVAL;
 

--- a/xml_utils.c
+++ b/xml_utils.c
@@ -80,7 +80,7 @@ char **get_xml_list(char * buf_dir_name, int *list_size)
 	const struct dirent *ent;
 	DIR *d;
 	char **list = NULL, **list1 = NULL;
-	char *extension_ptr;
+	const char *extension_ptr;
 	int cnt = 0;
 	int n = 0;
 


### PR DESCRIPTION
Hi, I run into some errors when trying to build the project from main branch source. This fix allowed the project to compile and run.

## Summary
- Fix `const` qualifier discarding warnings that cause build failures on Arch Linux with modern GCC
- In `osc.c`, cast `strchr()` return value to `gchar*` since the variable is used for mutation
- In `xml_utils.c`, declare `extension_ptr` as `const char*` since it's not modified

## Problem
Building on Arch Linux with modern GCC fails with:
```
xml_utils.c:95:39: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
osc.c:2864:13: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
```

The build uses `-Werror`, so warnings are treated as errors. `strchr()` and `strstr()` return `const char*` when passed a `const char*` argument, which cannot be assigned to a non-const pointer without an explicit cast.

## Testing
Successfully built and installed on Arch Linux with GCC 15.