### PR TITLE
Fix profile dialog and improve URI handling

### DIFF
--- a/dialogs.c
+++ b/dialogs.c
@@ -997,7 +997,7 @@ G_MODULE_EXPORT void cb_show_about(GtkButton *button, Dialogs *data)
 	gtk_widget_hide(data->about);
 }
 
-G_MODULE_EXPORT void load_save_profile_cb(GtkButton *button, Dialogs *data)
+void load_save_profile_cb(GtkButton *button, Dialogs *data)
 {
 	/* Save as Dialog */
 	gint ret;
@@ -1317,13 +1317,14 @@ G_MODULE_EXPORT void cb_check_for_updates(GtkCheckMenuItem *item, Dialogs *_dial
 void dialogs_init(GtkBuilder *builder)
 {
 	struct iio_context *ctx;
+	GtkButton *load_save_button;
 	GtkWidget *tmp;
 	bool scan = false;
 
 	dialogs.builder = builder;
 	dialogs.connect_devices_signals = 0;
 
-	dialogs.load_save_profile = GTK_WIDGET(gtk_builder_get_object(builder, "load_save_profile"));
+	load_save_button = GTK_BUTTON(gtk_builder_get_object(builder, "load_save_profile"));
 	GtkFileChooserAction action = GTK_FILE_CHOOSER_ACTION_OPEN;
 	dialogs.load_save_profile = GTK_WIDGET(gtk_file_chooser_dialog_new(
 		"Load/Save Profile", NULL, action, "Cancel", GTK_RESPONSE_CANCEL,
@@ -1365,7 +1366,7 @@ void dialogs_init(GtkBuilder *builder)
 	g_signal_connect(G_OBJECT(dialogs.connect_manual), "toggled",
 			(GCallback) connect_clear, NULL);
 
-
+	g_signal_connect(G_OBJECT(load_save_button), "activate", G_CALLBACK(load_save_profile_cb), &dialogs);
 	gtk_widget_set_sensitive(GTK_WIDGET(gtk_builder_get_object(builder, "scan_contexts_label")),
 			false);
 

--- a/glade/osc.glade
+++ b/glade/osc.glade
@@ -1179,13 +1179,12 @@ A GUI for Linux IIO devices</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="imagemenuitem4">
+                      <object class="GtkImageMenuItem" id="load_save_profile">
                         <property name="label" translatable="yes">Load/Save Profile</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="image">image4</property>
                         <property name="use-stock">False</property>
-                        <signal name="activate" handler="load_save_profile_cb" swapped="no"/>
                       </object>
                     </child>
                     <child>

--- a/osc.c
+++ b/osc.c
@@ -1128,7 +1128,6 @@ static void load_plugins(GtkWidget *notebook, const char *ini_fn)
 			GArray *plugin_info = get_plugins_info();
 
 			if (plugin_info == NULL) {
-				fprintf(stderr, "Failed to load plugin \"%s\"", ent->d_name);
 				dlclose(lib);
 				continue;
 			}
@@ -2134,6 +2133,20 @@ bool check_inifile(const char *filepath)
 	return TRUE;
 }
 
+char *get_profile_uri(const char *filename)
+{
+	const char *default_profile;
+
+	if (filename)
+		return read_token_from_ini(filename, OSC_INI_SECTION, "uri");
+
+	default_profile = get_default_profile_name();
+	if (default_profile && check_inifile(default_profile))
+		return read_token_from_ini(default_profile, OSC_INI_SECTION, "uri");
+
+	return NULL;
+}
+
 int load_default_profile(char *filename, bool load_plugins)
 {
 	int ret = 0;
@@ -2494,75 +2507,6 @@ static int load_profile(const char *filename, bool load_plugins)
 	close_all_plots();
 	destroy_all_plots();
 
-	value = read_token_from_ini(filename, OSC_INI_SECTION, "uri");
-	/* IP addresses specified on the command line via the -c option
-	 * override profile settings.
-	 */
-	if (value) {
-		struct iio_context *new_ctx = iio_create_context(NULL, value);
-		if (new_ctx) {
-			application_reload(new_ctx, false);
-		} else {
-			fprintf(stderr, "Failed connecting to remote device: %s\n", value);
-			/* Abort parsing the rest of the profile as there is
-			 * probably a lot of device specific stuff in it.
-			 */
-			free(value);
-			return 0;
-		}
-		free(value);
-	}
-
-	value = read_token_from_ini(filename, OSC_INI_SECTION, "uri");
-	/* URI addresses specified on the command line via the -u option
-	 * override profile settings
-	 */
-	if (value) {
-		struct iio_context *new_ctx;
-		struct iio_scan *ctxs = iio_scan(NULL, NULL);
-		char *pid_vid = value;
-		char *serial = strchr(value, ' ');
-		const char *tmp;
-		int i;
-		int ctxs_nb;
-
-		if (!serial)
-			goto nope;
-		usb_set_serialnumber(value);
-
-		pid_vid[serial - pid_vid] = 0;
-		serial++;
-
-		if (!ctxs)
-			goto nope;
-		ctxs_nb = iio_scan_get_results_count(ctxs);
-		ret = iio_err(ctxs);
-		if (ret < 0)
-			goto nope_ctxs;
-
-		for (i = 0; i < ctxs_nb; i++) {
-			tmp = iio_scan_get_description(ctxs, i);
-			/* find the correct PID/VID plus serial number*/
-			if (strstr(tmp, pid_vid) && strstr(tmp, serial)) {
-				new_ctx = iio_create_context(NULL,
-						iio_scan_get_uri(ctxs, i));
-				if (new_ctx) {
-					application_reload(new_ctx, false);
-					break;
-				} else {
-					fprintf(stderr, "Failed connecting to uri: %s\n", value);
-					free(value);
-					return 0;
-				}
-			}
-			}
-nope_ctxs:
-		iio_scan_destroy(ctxs);
-nope:
-		free(value);
-		ret = 0;
-	}
-
 	value = read_token_from_ini(filename, OSC_INI_SECTION, "test");
 	if (value) {
 		free(value);
@@ -2628,10 +2572,75 @@ nope:
 	return ret;
 }
 
+/* Return true if the profile is to be loaded, false otherwise */
+bool handle_profile_load_request(const char *filename, bool app_starting)
+{
+	char *uri_profile = get_profile_uri(filename);
+
+	if (!uri_profile) {
+		/* If there is no URI found in the profile, just blindly load it if it's
+		 * an explicit load request (through the UI). If the app is starting up, ignore
+		 * it.
+		 */
+		if (app_starting)
+			return false;
+
+		return true;
+	}
+
+	if (ctx) {
+		const struct iio_attr *ctx_uri = iio_context_find_attr(ctx, "uri");
+		const char *uri_val = iio_attr_get_static_value(ctx_uri);
+
+		if (strcmp(uri_profile, uri_val)) {
+			/* If the URI in the profile doesn't match the current context URI
+			 * reload the APP if not starting. We also tell application_reload()
+			 * to load the profile and hence we always return false given that
+			 * if we are starting up we won't load the profile on URI mismatch
+			 * (we favor the context passed through command line).
+			 */
+			struct iio_context *new_ctx;
+
+			if (app_starting) {
+				printf("URI mismatch, APP starting with different URI\n");
+				free(uri_profile);
+				return false;
+			}
+
+			new_ctx = iio_create_context(NULL, uri_profile);
+			free(uri_profile);
+			if (iio_err(new_ctx)) {
+				fprintf(stderr, "Failed to create new URI context: %d\n",
+					iio_err(new_ctx));
+				return false;
+			}
+
+			application_reload(new_ctx, true);
+			return false;
+		}
+
+		free(uri_profile);
+		return true;
+	}
+
+	ctx = iio_create_context(NULL, uri_profile);
+	free(uri_profile);
+	if (iio_err(ctx)) {
+		fprintf(stderr, "Failed to create new URI context: %d\n", iio_err(ctx));
+		ctx = NULL;
+		return false;
+	}
+
+	if (!app_starting)
+		do_init(ctx);
+
+	return true;
+}
 
 void load_complete_profile(const char *filename)
 {
-	load_profile(filename, true);
+	if (handle_profile_load_request(filename, false))
+		load_profile(filename, true);
 }
 
 struct iio_context * osc_create_context(void)

--- a/osc.h
+++ b/osc.h
@@ -169,6 +169,8 @@ int osc_plugin_default_handle(struct iio_context *ctx,
 GArray* get_data_for_possible_plugin_instances_helper(const char *dev_id, const char *plugin);
 
 /* Private functions */
+char *get_profile_uri(const char *filename);
+bool handle_profile_load_request(const char *filename, bool app_starting);
 extern int load_default_profile(char *filename, bool load_plugins);
 extern void do_init(struct iio_context *new_ctx);
 extern void create_default_plot(void);

--- a/oscmain.c
+++ b/oscmain.c
@@ -198,9 +198,8 @@ static void sigterm (int signum)
 gint main (int argc, char **argv)
 {
 	int c;
-
+	bool load_profile = true;
 	char *profile = NULL;
-
 	init_signal_handlers(argv[0]);
 
 	opterr = 0;
@@ -232,9 +231,12 @@ gint main (int argc, char **argv)
 #ifndef __MINGW__
 	signal(SIGHUP, sigterm);
 #endif
-
+	c = 0;
+	load_profile = handle_profile_load_request(profile, true);
 	init_application();
-	c = load_default_profile(profile, true);
+	if (load_profile)
+		c = load_default_profile(profile, true);
+
 	if (!ctx_destroyed_by_do_quit) {
 		if (!ctx)
 			connect_dialog(false);


### PR DESCRIPTION
## PR Description

 - Fix the Load/Save Profile dialog appearing twice on every click by wiring the signal handler in code rather than through Glade auto-connection.
 - Refactor how profile URIs are resolved during startup and profile loading. Previously, loading any profile would unconditionally reload the application — even when already connected to the matching URI — and command-line URIs (-u) could be silently overridden by a saved profile. The new handle_profile_load_request() compares URIs before
deciding whether a reload is actually needed.

@dNechita, note that I completely removed [this code](https://github.com/analogdevicesinc/iio-oscilloscope/blob/main/osc.c#L2501) given I'm not sure why it's here but it is clear that, in it's current form, it has lots of issues:

* Getting the URI twice;
* This hidden app reloading ;
* Even after getting a valid URI, we do an IIO scan and do all of that USB related stuff

So If you think we still need all of that USB stuff let me know, so we can see how can bring it back in a sane way.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
