### PR TITLE
fix impulse generator menu

### DIFF
--- a/oscplot.c
+++ b/oscplot.c
@@ -6784,10 +6784,7 @@ static gboolean right_click_menu_show(OscPlot *plot, GdkEvent *event)
 		int ret;
 
 		ret = iio_device_get_trigger(dev, &trigger);
-		needs_trigger = false;
-		if (ret == 0) {
-			needs_trigger = true;
-		}
+		needs_trigger = (ret == 0 || ret == -ENOENT || ret == -ENODEV || ret == -EIO);
 
 		gtk_widget_set_sensitive(priv->device_trigger_menuitem,
 				needs_trigger);


### PR DESCRIPTION
## PR Description
Impulse Generator menu is enabled when iio_device_get_trigger returns a value which means the device supports a trigger: 
- 0 - trigger assigned
- -ENOENT, -ENODEV, -EIO - trigger supported , not assigned 

- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particulary complex or unclear areas 
- [x] I have checked in CI output that no new warnings/errors got introduced
- [x] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
