### PR TITLE
Deb fixes

### DIFF
--- a/dialogs.c
+++ b/dialogs.c
@@ -592,8 +592,11 @@ static void refresh_usb_thread(void)
 	usb_devices_info->device_list = calloc(ret, sizeof(char *));
 
 	for (i = 0; i < (size_t) ret; i++) {
-		tmp = strdup(iio_context_info_get_description(info[i]));
-		pid = strdup(iio_context_info_get_description(info[i]));
+		const char *desc = iio_context_info_get_description(info[i]);
+		if (!desc)
+			continue;
+		tmp = strdup(desc);
+		pid = strdup(desc);
 
 		/* skip the PID/VID or IP Number, example descriptions are:
 		 * 0456:b673 (Analog Devices Inc. PlutoSDR (ADALM-PLUTO)), serial=104473541196000618001900241f1e6931
@@ -750,13 +753,13 @@ static void fillin_result_free(struct fillin_result *res)
 
 	if (!res)
 		return;
-	free(res->desc);
+	g_free(res->desc);
 	if (res->dev_names) {
 		for (i = 0; i < res->n_devs; i++)
-			free(res->dev_names[i]);
+			g_free(res->dev_names[i]);
 		free(res->dev_names);
 	}
-	free(res->attrs_text);
+	g_free(res->attrs_text);
 	if (res->eeprom_paths) {
 		for (i = 0; i < res->n_eeproms; i++)
 			free(res->eeprom_paths[i]);
@@ -832,13 +835,13 @@ static gpointer fillin_thread_func(gpointer data)
 		res->desc = g_strdup_printf("Could not get IIO Context: %s...",
 					    strerror(res->saved_errno));
 	} else {
-		res->desc = strdup(iio_context_get_description(res->ctx));
+		res->desc = g_strdup(iio_context_get_description(res->ctx));
 		res->n_devs = iio_context_get_devices_count(res->ctx);
 		if (res->n_devs) {
 			res->dev_names = calloc(res->n_devs, sizeof(char *));
 			for (i = 0; i < res->n_devs; i++) {
 				struct iio_device *dev = iio_context_get_device(res->ctx, i);
-				res->dev_names[i] = strdup(get_iio_device_label_or_name(dev));
+				res->dev_names[i] = g_strdup(get_iio_device_label_or_name(dev));
 			}
 		}
 

--- a/phone_home.c
+++ b/phone_home.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <curl/curl.h>
+#include <glib.h>
 #include <jansson.h>
 
 #include "phone_home.h"
@@ -210,16 +211,11 @@ void release_dispose(Release *_this)
 	if (!_this)
 		return;
 
-	if (_this->name)
-		free(_this->name);
-	if (_this->build_date)
-		free(_this->build_date);
-	if (_this->commit)
-		free(_this->commit);
-	if (_this->url)
-		free(_this->url);
-	if (_this->windows_dld_url)
-		free(_this->windows_dld_url);
+	g_free(_this->name);
+	g_free(_this->build_date);
+	g_free(_this->commit);
+	g_free(_this->url);
+	g_free(_this->windows_dld_url);
 }
 
 Release * release_get_latest(void)
@@ -247,9 +243,9 @@ Release * release_get_latest(void)
 		goto cleanup_and_fail;
 	}
 
-	release->name = strdup(json_string_value(json_object_get(j_release, "name")));
-	release->build_date = strdup(json_string_value(json_object_get(j_release, "created_at")));
-	release->url = strdup(json_string_value(json_object_get(j_release, "html_url")));
+	release->name = g_strdup(json_string_value(json_object_get(j_release, "name")));
+	release->build_date = g_strdup(json_string_value(json_object_get(j_release, "created_at")));
+	release->url = g_strdup(json_string_value(json_object_get(j_release, "html_url")));
 
 	/* Get the release SHA commit */
 	json_t *j_tags, *tag, *name, *commit;
@@ -275,7 +271,7 @@ Release * release_get_latest(void)
 			commit = json_object_get(tag, "commit");
 			if (!json_is_object(commit))
 				break;
-			release->commit = strdup(json_string_value(
+			release->commit = g_strdup(json_string_value(
 					json_object_get(commit, "sha")));
 		}
 	}
@@ -297,7 +293,7 @@ Release * release_get_latest(void)
 		release_abort = true;
 		goto cleanup_and_fail;
 	}
-	release->windows_dld_url = strdup(json_string_value(json_object_get(w_build, "browser_download_url")));
+	release->windows_dld_url = g_strdup(json_string_value(json_object_get(w_build, "browser_download_url")));
 
 cleanup_and_fail:
 	if (release_abort) {


### PR DESCRIPTION
## PR Description

Latest round of fixes, introduced a crash on zynq targets. By adding a NULL check for iio_get_context_description and replacing strdup and free with their glib equivalents , NULL returns are handled gracefully, preventing the crash.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
