### PR TITLE
dialogs.c: use g_strdup

### DIFF
--- a/dialogs.c
+++ b/dialogs.c
@@ -832,13 +832,13 @@ static gpointer fillin_thread_func(gpointer data)
 		res->desc = g_strdup_printf("Could not get IIO Context: %s...",
 					    strerror(res->saved_errno));
 	} else {
-		res->desc = strdup(iio_context_get_description(res->ctx));
+		res->desc = g_strdup(iio_context_get_description(res->ctx));
 		res->n_devs = iio_context_get_devices_count(res->ctx);
 		if (res->n_devs) {
 			res->dev_names = calloc(res->n_devs, sizeof(char *));
 			for (i = 0; i < res->n_devs; i++) {
 				struct iio_device *dev = iio_context_get_device(res->ctx, i);
-				res->dev_names[i] = strdup(get_iio_device_label_or_name(dev));
+				res->dev_names[i] = g_strdup(get_iio_device_label_or_name(dev));
 			}
 		}
 


### PR DESCRIPTION
use g_strdup instead of strdup to handle null pointers gracefully. this prevents segmentation faults.

## PR Description

- Please replace this comment with a summary of your changes, and add any context 
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without 
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the 
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have checked in CI output that no new warnings/errors got introduced
- [ ] I have updated documentation accordingly (GitHub Pages, READMEs, etc)
